### PR TITLE
fix: add directUrl to prisma config for neon connection stability

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("POSTGRES_URL_NON_POOLING")
 }
 
 model Aide {


### PR DESCRIPTION
# Fix: Stabilize Prisma/Neon Connection

This PR adds the `directUrl` configuration to `prisma/schema.prisma`.

## Why?
Neon Serverless Postgres requires two connection strings when used with Vercel Serverless Functions:
1.  `url` (Pooled): Used by the application (Prisma Client) to manage connection limits effectively.
2.  `directUrl` (Non-Pooled): Used by Prisma Migrations (`prisma migrate`) to ensure transactions work correctly.

Without `directUrl`, migrations or heavy operations can fail with "Can't reach database server" or transaction errors.

## Changes
- Updated `prisma/schema.prisma`:
    ```prisma
    datasource db {
      provider  = "postgresql"
      url       = env("DATABASE_URL")
      directUrl = env("POSTGRES_URL_NON_POOLING")
    }
    ```

## Verification
- Regenerated Prisma Client (`npx prisma generate`).
