### PR TITLE
fix: split cron pipeline by source and add smoke mode

### DIFF
--- a/api/_handlers/cron/ingest-aids.js
+++ b/api/_handlers/cron/ingest-aids.js
@@ -39,6 +39,15 @@ export default async function handler(req, res) {
             console.warn("External source unreachable, skipping automated enrichment.");
         }
 
+        // Limit support
+        const limitParam = req.query.limit;
+        if (limitParam) {
+            const limit = parseInt(limitParam, 10);
+            if (limit > 0) {
+                externalAids = externalAids.slice(0, limit);
+            }
+        }
+
         // Process items
         for (const item of externalAids) {
             const hash = crypto.createHash('md5').update(JSON.stringify(item)).digest('hex');

--- a/api/_handlers/cron/ingest-structures.js
+++ b/api/_handlers/cron/ingest-structures.js
@@ -58,7 +58,13 @@ export default async function handler(req, res) {
             }
 
             const data = await response.json();
-            const items = data.results || data.records || [];
+            let items = data.results || data.records || [];
+
+            // Limit support
+            const limit = req.query.limit ? parseInt(req.query.limit, 10) : undefined;
+            if (limit && limit > 0) {
+                items = items.slice(0, limit);
+            }
 
             for (const item of items) {
                 try {

--- a/api/_handlers/cron/pipeline.js
+++ b/api/_handlers/cron/pipeline.js
@@ -34,7 +34,8 @@ export default async function handler(req, res) {
     }
 
     // req.query is available in Vercel function, or parsed by dev-server
-    const secret = req.query?.secret || new URL(req.url, `http://${req.headers.host}`).searchParams.get('secret');
+    const query = req.query || {};
+    const secret = query.secret || new URL(req.url, `http://${req.headers.host}`).searchParams.get('secret');
     const vercelCronHeader = req.headers['x-vercel-cron'];
     const authHeader = req.headers['authorization'];
 
@@ -48,6 +49,21 @@ export default async function handler(req, res) {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
+    // 2. Validation & Parameters
+    const source = query.source; // 'structures', 'aides', 'rss'
+    const mode = query.mode; // 'smoke'
+    const limitParam = query.limit;
+
+    // Determine limit: explicit > smoke default (5) > undefined (unlimited)
+    let limit = limitParam ? parseInt(limitParam, 10) : (mode === 'smoke' ? 5 : undefined);
+
+    if (!source) {
+        return res.status(400).json({
+            ok: false,
+            error: "Missing required 'source' parameter. Options: 'structures', 'aides', 'rss'."
+        });
+    }
+
     const runId = crypto.randomUUID();
     const stats = {
         ingested: 0,
@@ -55,6 +71,7 @@ export default async function handler(req, res) {
         published: 0,
         errors: []
     };
+    const startTime = Date.now();
 
     // Helper: Retry wrapper
     async function retry(fn, retries = 3, delay = 1000) {
@@ -75,184 +92,236 @@ export default async function handler(req, res) {
 
     const pipelineLogic = async () => {
         // ==========================================
-        // STEP 0: SEED CONFIG (Ensure Sources Exist)
+        // ROUTING LOGIC
         // ==========================================
-        try {
-            const configPath = path.join(process.cwd(), 'config', 'rss-sources.json');
-            if (fs.existsSync(configPath)) {
-                const configSources = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-                for (const src of configSources) {
-                    await prisma.rssSource.upsert({
-                        where: { feed_url: src.url },
-                        update: {
-                            name: src.name,
-                            domain: src.domain,
-                            trust_level: src.trust_level,
-                            enabled: true // Re-enable if in config
-                        },
-                        create: {
-                            name: src.name,
-                            feed_url: src.url,
-                            domain: src.domain,
-                            trust_level: src.trust_level,
-                            enabled: true
+
+        if (source === 'structures') {
+            try {
+                // Pass limit via query to the handler
+                const subQuery = { secret: process.env.CRON_SECRET };
+                if (limit) subQuery.limit = limit.toString();
+
+                await ingestStructures({ query: subQuery }, {
+                    status: () => ({
+                        json: (d) => {
+                            if (d) {
+                                stats.ingested += (d.created || 0);
+                                if (d.errors) stats.errors.push(...d.errors);
+                            }
                         }
+                    })
+                });
+            } catch (e) {
+                console.error("Pipeline: Ingest Structures failed", e);
+                stats.errors.push(`Structures failed: ${e.message}`);
+                throw e; // Propagate to trigger failure response
+            }
+
+        } else if (source === 'aides') {
+            try {
+                const subQuery = { secret: process.env.CRON_SECRET };
+                if (limit) subQuery.limit = limit.toString();
+
+                await ingestAids({ query: subQuery }, {
+                    status: () => ({
+                        json: (d) => {
+                            if (d) {
+                                stats.ingested += (d.created || 0);
+                                if (d.errors) stats.errors.push(...d.errors);
+                            }
+                        }
+                    })
+                });
+            } catch (e) {
+                console.error("Pipeline: Ingest Aids failed", e);
+                stats.errors.push(`Aids failed: ${e.message}`);
+                throw e;
+            }
+
+        } else if (source === 'rss') {
+            // ==========================================
+            // RSS INGESTION
+            // ==========================================
+            // Step 0: Ensure Config Exists (Upsert Sources)
+            try {
+                const configPath = path.join(process.cwd(), 'config', 'rss-sources.json');
+                if (fs.existsSync(configPath)) {
+                    const configSources = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+                    for (const src of configSources) {
+                        await prisma.rssSource.upsert({
+                            where: { feed_url: src.url },
+                            update: {
+                                name: src.name,
+                                domain: src.domain,
+                                trust_level: src.trust_level,
+                                enabled: true
+                            },
+                            create: {
+                                name: src.name,
+                                feed_url: src.url,
+                                domain: src.domain,
+                                trust_level: src.trust_level,
+                                enabled: true
+                            }
+                        });
+                    }
+                }
+            } catch (e) {
+                console.error("Pipeline: Seed Config failed", e);
+                stats.errors.push(`Config Seed failed: ${e.message}`);
+            }
+
+            const sources = await prisma.rssSource.findMany({ where: { enabled: true } });
+
+            let processedCount = 0;
+            // Apply limit across ALL sources or per source? 
+            // 'limit' usually implies total items for this run.
+            // We'll stop after reaching limit total items.
+
+            for (const source of sources) {
+                if (limit && processedCount >= limit) break;
+
+                try {
+                    const feed = await retry(() => parser.parseURL(source.feed_url));
+
+                    // Slice feed items if remainder of limit is small
+                    let itemsToProcess = feed.items;
+                    if (limit) {
+                        const remaining = limit - processedCount;
+                        itemsToProcess = itemsToProcess.slice(0, remaining);
+                    }
+
+                    for (const item of itemsToProcess) {
+                        const rawContent = `${item.title}${item.link}`;
+                        const hash = crypto.createHash('md5').update(rawContent).digest('hex');
+                        const isOfficial = source.trust_level === 'OFFICIAL';
+
+                        try {
+                            const itemSlug = await ensureSlug(prisma, 'actualite', {
+                                id: null,
+                                titre: item.title || "Sans titre",
+                                slug: null
+                            }, 'titre');
+
+                            const upsertData = {
+                                titre: item.title || "Sans titre",
+                                slug: itemSlug || (slugify(item.title || "info") + '-' + hash.substring(0, 6)),
+                                contenu: item.content || item.contentSnippet || "",
+                                resume: item.contentSnippet || item.content || "",
+                                canonical_url: item.link,
+                                guid: item.guid || item.link,
+                                source_id: source.id,
+                                source_name: source.name,
+                                source_url: source.feed_url,
+                                dedupe_hash: hash,
+                                ingest_batch: runId,
+                                statut: "brouillon",
+                                falc_status: "pending",
+                                quality_score: isOfficial ? 60 : 40,
+                                auto_publish: isOfficial,
+                                date_publication: item.isoDate ? new Date(item.isoDate) : new Date(),
+                                fetched_at: new Date(),
+                                tags: []
+                            };
+
+                            const result = await prisma.actualite.upsert({
+                                where: { raw_data_hash: hash },
+                                update: {},
+                                create: { ...upsertData, raw_data_hash: hash }
+                            });
+
+                            if (Math.abs(result.fetched_at - upsertData.fetched_at) < 2000) {
+                                stats.ingested++;
+                            }
+                            processedCount++;
+
+                        } catch (e) {
+                            if (!e.message.includes('Unique constraint')) {
+                                throw e;
+                            }
+                        }
+                    }
+                } catch (err) {
+                    console.error(`Error processing source ${source.name}:`, err.message);
+                    stats.errors.push(`${source.name}: ${err.message}`);
+                }
+            }
+
+            // RSS specific: Enrichment & Publication (Optional: could also be separate steps/sources)
+            // For now, keep them part of 'rss' run but respect limit?
+            // Usually enrichment is separate, but let's keep it here for continuity unless 'limit' prevented ingestion.
+
+            // ... (Keeping existing enrichment/publish logic for brevity, assuming it runs on pending items)
+            // Ideally, we only enrich what we just ingested or small batch.
+
+            // STEP 2: ENRICHMENT
+            const itemsToEnrich = await prisma.actualite.findMany({
+                where: { falc_status: 'pending' },
+                take: limit ? Math.min(limit, 5) : 5, // Respect limit or default 5
+                orderBy: { fetched_at: 'desc' }
+            });
+
+            for (const item of itemsToEnrich) {
+                // ... enrichment logic (same as before)
+                try {
+                    const falcResult = await summarizeToFalc(item.contenu || item.titre, `Source: ${item.source_name}`);
+                    await prisma.actualite.update({
+                        where: { id: item.id },
+                        data: {
+                            summary_falc: falcResult.summary,
+                            key_points_falc: falcResult.key_points,
+                            falc_status: 'generated',
+                            quality_score: { increment: 20 }
+                        }
+                    });
+                    stats.enriched++;
+                } catch (err) {
+                    console.error(`Error enriching item ${item.id}:`, err);
+                    await prisma.actualite.update({
+                        where: { id: item.id },
+                        data: { falc_status: 'failed' }
                     });
                 }
             }
-        } catch (e) {
-            console.error("Pipeline: Seed Config failed", e);
-        }
 
-        // ==========================================
-        // STEP 0.5: CORE INGESTION (Structures & Aids)
-        // ==========================================
-        // Structures
-        try {
-            await ingestStructures({ query: { secret: process.env.CRON_SECRET } }, {
-                status: () => ({ json: (d) => { if (d && d.created) stats.ingested += d.created; } })
+            // STEP 3: PUBLICATION
+            const threshold = 75;
+            const toPublish = await prisma.actualite.findMany({
+                where: {
+                    statut: 'brouillon',
+                    auto_publish: true,
+                    quality_score: { gte: threshold },
+                    falc_status: { in: ['generated'] }
+                },
+                take: limit ? limit : undefined // Optional: limit publication too?
             });
-        } catch (e) { console.error("Pipeline: Ingest Structures failed", e); }
 
-        // Aids
-        try {
-            await ingestAids({ query: { secret: process.env.CRON_SECRET } }, {
-                status: () => ({ json: (d) => { if (d && d.created) stats.ingested += d.created; } })
-            });
-        } catch (e) { console.error("Pipeline: Ingest Aids failed", e); }
-
-        // ==========================================
-        // STEP 1: RSS INGESTION
-        // ==========================================
-        const sources = await prisma.rssSource.findMany({ where: { enabled: true } });
-
-        for (const source of sources) {
-            try {
-                const feed = await retry(() => parser.parseURL(source.feed_url));
-
-                for (const item of feed.items) {
-                    const rawContent = `${item.title}${item.link}`;
-                    const hash = crypto.createHash('md5').update(rawContent).digest('hex');
-                    const isOfficial = source.trust_level === 'OFFICIAL';
-
-                    // Using upsert to handle concurrency and idempotency
-                    // Note: We catch potential conflicts on canonical_url if it differs from hash
-                    try {
-                        // Generate slug (with collision handling)
-                        const itemSlug = await ensureSlug(prisma, 'actualite', {
-                            id: null, // No ID yet for new items
-                            titre: item.title || "Sans titre",
-                            slug: null
-                        }, 'titre');
-
-                        const upsertData = {
-                            titre: item.title || "Sans titre",
-                            slug: itemSlug || (slugify(item.title || "info") + '-' + hash.substring(0, 6)), // Fallback
-                            contenu: item.content || item.contentSnippet || "",
-                            resume: item.contentSnippet || item.content || "", // Raw summary
-                            canonical_url: item.link,
-                            guid: item.guid || item.link,
-                            source_id: source.id,
-                            source_name: source.name,
-                            source_url: source.feed_url,
-                            dedupe_hash: hash,
-                            ingest_batch: runId,
-                            statut: "brouillon", // Default to draft, auto-publish step will handle it
-                            falc_status: "pending",
-                            quality_score: isOfficial ? 60 : 40,
-                            auto_publish: isOfficial,
-                            date_publication: item.isoDate ? new Date(item.isoDate) : new Date(),
-                            fetched_at: new Date(),
-                            tags: [] // Can map from source if available
-                        };
-
-                        const result = await prisma.actualite.upsert({
-                            where: { raw_data_hash: hash },
-                            update: {},
-                            create: { ...upsertData, raw_data_hash: hash }
-                        });
-
-                        // We count it if it was created recently (approx check)
-                        if (Math.abs(result.fetched_at - upsertData.fetched_at) < 2000) {
-                            stats.ingested++;
-                        }
-                    } catch (e) {
-                        if (!e.message.includes('Unique constraint')) {
-                            throw e;
-                        }
-                        // Ignore duplicate canonical_url
-                    }
-                }
-            } catch (err) {
-                console.error(`Error processing source ${source.name}:`, err.message);
-                stats.errors.push(`${source.name}: ${err.message}`);
-            }
-        }
-
-        // ==========================================
-        // STEP 2: ENRICHMENT (FALC & Tags)
-        // ==========================================
-        const itemsToEnrich = await prisma.actualite.findMany({
-            where: { falc_status: 'pending' },
-            take: 5,
-            orderBy: { fetched_at: 'desc' }
-        });
-
-        for (const item of itemsToEnrich) {
-            try {
-                const falcResult = await summarizeToFalc(item.contenu || item.titre, `Source: ${item.source_name}`);
-
+            for (const item of toPublish) {
                 await prisma.actualite.update({
                     where: { id: item.id },
                     data: {
-                        summary_falc: falcResult.summary,
-                        key_points_falc: falcResult.key_points,
-                        falc_status: 'generated',
-                        quality_score: { increment: 20 }
+                        statut: 'publie',
+                        published_at: new Date()
                     }
                 });
-                stats.enriched++;
-            } catch (err) {
-                console.error(`Error enriching item ${item.id}:`, err);
-                await prisma.actualite.update({
-                    where: { id: item.id },
-                    data: { falc_status: 'failed' }
-                });
+                stats.published++;
             }
-        }
 
-        // ==========================================
-        // STEP 3: PUBLICATION
-        // ==========================================
-        const threshold = 75;
-        const toPublish = await prisma.actualite.findMany({
-            where: {
-                statut: 'brouillon',
-                auto_publish: true,
-                quality_score: { gte: threshold },
-                falc_status: { in: ['generated'] }
-            }
-        });
-
-        for (const item of toPublish) {
-            await prisma.actualite.update({
-                where: { id: item.id },
-                data: {
-                    statut: 'publie', // FIXED: actif -> publie
-                    published_at: new Date()
-                }
-            });
-            stats.published++;
+        } else {
+            const err = new Error(`Invalid source '${source}'. Valid: structures, aides, rss`);
+            // We'll throw so it's caught and correctly errored
+            throw err;
         }
 
         // Log the Run
         await prisma.importLog.create({
             data: {
-                source_name: 'CRON_PIPELINE',
+                source_name: `CRON_${source.toUpperCase()}`,
                 status: stats.errors.length > 0 ? 'PARTIAL' : 'SUCCESS',
                 items_new: stats.ingested,
                 items_total: stats.ingested + stats.enriched + stats.published,
-                logs: stats.errors.length ? JSON.stringify(stats.errors) : null
+                logs: stats.errors.length ? JSON.stringify(stats.errors) : null,
+                duration_ms: Date.now() - startTime
             }
         });
     };
@@ -261,19 +330,34 @@ export default async function handler(req, res) {
         await Promise.race([pipelineLogic(), timeoutPromise]);
     } catch (globalErr) {
         console.error("Pipeline Global Error:", globalErr);
-        // Try to log the failure to DB if possible
+        // Try to log failure
         try {
             await prisma.importLog.create({
                 data: {
-                    source_name: 'CRON_PIPELINE',
+                    source_name: `CRON_${source ? source.toUpperCase() : 'UNKNOWN'}`,
                     status: 'ERROR',
-                    logs: JSON.stringify(globalErr.message)
+                    logs: JSON.stringify(globalErr.message),
+                    duration_ms: Date.now() - startTime
                 }
             });
         } catch (e) { /* ignore */ }
 
-        return res.status(500).json({ error: globalErr.message });
+        // Use 400 for bad requests, 500 for others
+        const statusCode = globalErr.message.includes('Invalid source') ? 400 : 500;
+        return res.status(statusCode).json({
+            ok: false,
+            error: globalErr.message,
+            source,
+            mode,
+            durationMs: Date.now() - startTime
+        });
     }
 
-    return res.status(200).json(stats);
+    return res.status(200).json({
+        ok: true,
+        source,
+        mode,
+        durationMs: Date.now() - startTime,
+        stats
+    });
 }

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -20,7 +20,16 @@ Ce document décrit les procédures de résolution d'incidents et de maintenance
 ### Cron Jobs en échec
 1. Vérifier `/api/admin/runs` pour voir les logs d'exécution.
 2. Si timeout, réduire le volume de données traité par batch.
-3. Déclencher manuellement via l'URL : `curl -H "Authorization: Bearer <CRON_SECRET>" https://.../api/cron/pipeline`
+3. Déclencher manuellement via l'URL :
+   ```bash
+   # Run Structures (Limit default)
+   curl -X POST "https://.../api/cron/pipeline?source=structures" \
+     -H "Authorization: Bearer <CRON_SECRET>"
+
+   # Run Aids (Smoke Check - 5 items)
+   curl -X POST "https://.../api/cron/pipeline?source=aides&mode=smoke" \
+     -H "Authorization: Bearer <CRON_SECRET>"
+   ```
 
 ## Procédures de Rollback
 

--- a/tests/integration/pipeline_routing.test.js
+++ b/tests/integration/pipeline_routing.test.js
@@ -1,0 +1,91 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import pipelineHandler from '../../api/_handlers/cron/pipeline.js';
+
+// Mock dependencies
+vi.mock('../../api/_handlers/cron/ingest-structures.js', () => ({
+    default: vi.fn().mockResolvedValue({ created: 10, errors: [] })
+}));
+vi.mock('../../api/_handlers/cron/ingest-aids.js', () => ({
+    default: vi.fn().mockResolvedValue({ created: 5, errors: [] })
+}));
+vi.mock('@prisma/client', () => {
+    const MockPrismaClient = vi.fn();
+    MockPrismaClient.prototype.rssSource = {
+        upsert: vi.fn(),
+        findMany: vi.fn().mockResolvedValue([]),
+    };
+    MockPrismaClient.prototype.importLog = {
+        create: vi.fn(),
+    };
+    MockPrismaClient.prototype.$disconnect = vi.fn();
+    return { PrismaClient: MockPrismaClient };
+});
+
+// Setup req/res mocks
+const createMocks = (query = {}, headers = {}) => {
+    const req = {
+        query,
+        headers: { host: 'localhost', ...headers },
+        url: '/api/cron/pipeline'
+    };
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn()
+    };
+    return { req, res };
+};
+
+describe('Cron Pipeline Routing', () => {
+    const CRON_SECRET = 'test_secret';
+
+    beforeEach(() => {
+        process.env.CRON_SECRET = CRON_SECRET;
+        vi.clearAllMocks();
+    });
+
+    it('should return 401 if unauthorized', async () => {
+        const { req, res } = createMocks({});
+        await pipelineHandler(req, res);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('should return 400 if source is missing', async () => {
+        const { req, res } = createMocks({ secret: CRON_SECRET });
+        await pipelineHandler(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining("Missing required 'source'") }));
+    });
+
+    it('should route to structures when source=structures', async () => {
+        const { req, res } = createMocks({ secret: CRON_SECRET, source: 'structures' });
+        const ingestStructures = (await import('../../api/_handlers/cron/ingest-structures.js')).default;
+
+        await pipelineHandler(req, res);
+
+        expect(ingestStructures).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ source: 'structures', ok: true }));
+    });
+
+    it('should pass limiting params when mode=smoke', async () => {
+        const { req, res } = createMocks({ secret: CRON_SECRET, source: 'structures', mode: 'smoke' });
+        const ingestStructures = (await import('../../api/_handlers/cron/ingest-structures.js')).default;
+
+        await pipelineHandler(req, res);
+
+        // Check if limit was passed (implementation detail: pipeline passes query with limit)
+        const callArgs = ingestStructures.mock.calls[0][0]; // first arg is req-like object
+        expect(callArgs.query.limit).toBe("5");
+    });
+
+    it('should return 400 for invalid source', async () => {
+        const { req, res } = createMocks({ secret: CRON_SECRET, source: 'invalid' });
+
+        await pipelineHandler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ok: false, error: expect.stringContaining("Invalid source") }));
+    });
+});


### PR DESCRIPTION
# Fix: Split Cron Pipeline & Add Smoke Mode (Mission P0)

This PR resolves internal timeouts (50s) in the Vercel Serverless environment by splitting the monolithic pipeline into source-specific executions and adding a "smoke" mode for quick validation.

## Changes
- **Refactor `api/_handlers/cron/pipeline.js`**:
    - **Source Routing**: Requires `source` query param (`structures`, `aides`, `rss`). Returns 400 if missing.
    - **Source Isolation**: Executes ONLY the requested source logic, preventing timeouts from cumulative processing.
    - **Smoke Mode**: Adds `mode=smoke` (or `limit=X`) to restrict processing to a small number of items (default 5 for smoke).
    - **Standardized Response**: Returns ` { ok: true, source, mode, durationMs, stats }` or structured error.
- **Update Ingestion Handlers**:
    - Updated `ingest-structures.js` and `ingest-aids.js` to accept and respect a `limit` parameter.
- **Documentation**: Updated `docs/RUNBOOK.md` with new curl examples.
- **Tests**: Added `tests/integration/pipeline_routing.test.js` to verify routing, auth, and parameter handling.

## Verification
- **Tests**: `npx vitest run tests/integration/pipeline_routing.test.js` (Passed).
- **Manual Curl (Post-Deployment)**:
    ```bash
    curl -X POST ".../api/cron/pipeline?source=structures&mode=smoke" -H "Authorization: Bearer ..."
    ```
