### PR TITLE
fix: unify cron auth (Bearer/secret/header) + robustness logs

### DIFF
--- a/api/_handlers/cron/ingest-aids.js
+++ b/api/_handlers/cron/ingest-aids.js
@@ -1,3 +1,4 @@
+import { isCronAuthorized } from '../../_utils/cronAuth.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
 
@@ -16,8 +17,7 @@ function slugify(text) {
 }
 
 export default async function handler(req, res) {
-    const secret = req.query.secret;
-    if (!process.env.CRON_SECRET || secret !== process.env.CRON_SECRET) {
+    if (!isCronAuthorized(req)) {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
@@ -49,7 +49,15 @@ export default async function handler(req, res) {
             stats.durationByStage.fetchMs = Date.now() - startFetch;
 
             if (response.ok) {
+                // Anti Silent Failure Logs
+                // We check headers/content-type if needed, but here response.ok means we got it.
+                // We read JSON and THEN check length.
                 externalAids = await response.json();
+
+                if (!externalAids || externalAids.length === 0) {
+                    console.warn(`[AIDS] 0 items. status=${response.status} ct=${response.headers.get('content-type')} keys=${Array.isArray(externalAids) ? '[]' : Object.keys(externalAids).join(',')}`);
+                }
+
                 stats.fetched = externalAids.length;
             }
         } catch (e) {

--- a/api/_handlers/cron/ingest-structures.js
+++ b/api/_handlers/cron/ingest-structures.js
@@ -1,3 +1,4 @@
+import { isCronAuthorized } from '../../_utils/cronAuth.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
 // Native fetch used
@@ -14,17 +15,6 @@ const DATASETS = [
     }
 ];
 
-// Helper: Safe Header Access
-function getHeader(req, name) {
-    const n = name.toLowerCase();
-    const h = req?.headers;
-    // Fetch/Edge style
-    if (h && typeof h.get === "function") return h.get(name) ?? h.get(n) ?? undefined;
-    // Node style
-    if (h && typeof h === "object") return h[n] ?? h[name] ?? undefined;
-    return undefined;
-}
-
 function slugify(text) {
     if (!text) return '';
     return text.toString().toLowerCase().trim()
@@ -37,15 +27,7 @@ function slugify(text) {
 
 export default async function handler(req, res) {
     // 1. Authorization
-    if (!process.env.CRON_SECRET) {
-        console.error("CRITICAL: CRON_SECRET environment variable is not defined.");
-        return res.status(500).json({ error: 'Server configuration error' });
-    }
-
-    const secret = req.query?.secret || new URL(req.url, 'http://localhost').searchParams.get('secret');
-    const vercelCronHeader = getHeader(req, 'x-vercel-cron');
-
-    if (secret !== process.env.CRON_SECRET && vercelCronHeader !== '1') {
+    if (!isCronAuthorized(req)) {
         console.warn("Unauthorized Ingest-Structures Attempt");
         return res.status(401).json({ error: 'Unauthorized' });
     }
@@ -81,6 +63,12 @@ export default async function handler(req, res) {
 
             const data = await response.json();
             let items = data.results || data.records || [];
+
+            // Anti Silent Failure Logging
+            if (!items || items.length === 0) {
+                console.warn(`[STRUCTURES] 0 items. status=${response.status} ct=${response.headers.get('content-type')} keys=${data ? Object.keys(data).join(',') : 'null'}`);
+            }
+
             stats.fetched += items.length;
 
             // Limit support

--- a/api/_handlers/cron/pipeline.js
+++ b/api/_handlers/cron/pipeline.js
@@ -1,4 +1,5 @@
 /* global process */
+import { isCronAuthorized } from '../../_utils/cronAuth.js';
 import { PrismaClient } from '@prisma/client';
 import Parser from 'rss-parser';
 import crypto from 'crypto';
@@ -26,38 +27,14 @@ function slugify(text) {
         .replace(/-+$/, '');
 }
 
-// Helper: Safe Header Access
-function getHeader(req, name) {
-    const n = name.toLowerCase();
-    const h = req?.headers;
-    if (h && typeof h.get === "function") return h.get(name) ?? h.get(n) ?? undefined;
-    if (h && typeof h === "object") return h[n] ?? h[name] ?? undefined;
-    return undefined;
-}
-
 export default async function handler(req, res) {
     // 1. Authorization
-    if (!process.env.CRON_SECRET) {
-        console.error("CRITICAL: CRON_SECRET environment variable is not defined.");
-        return res.status(500).json({ error: 'Server configuration error' });
-    }
-
-    const query = req.query || {};
-    // Safe header access
-    const secret = query.secret || new URL(req.url, `http://${req.headers?.host || 'localhost'}`).searchParams.get('secret');
-    const vercelCronHeader = getHeader(req, 'x-vercel-cron');
-    const authHeader = getHeader(req, 'authorization');
-
-    const isAuthorized =
-        secret === process.env.CRON_SECRET ||
-        vercelCronHeader === '1' ||
-        authHeader === `Bearer ${process.env.CRON_SECRET}`;
-
-    if (!isAuthorized) {
+    if (!isCronAuthorized(req)) {
         console.warn("Unauthorized Pipeline Attempt");
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
+    const query = req.query || {};
     // 2. Validation & Parameters (with Aliases)
     let sourceInput = query.source;
     let sourceResolved = sourceInput;
@@ -138,12 +115,15 @@ export default async function handler(req, res) {
         // ROUTING LOGIC
         // ==========================================
 
+        // Pass original headers to sustain auth
+        const proxyHeaders = req.headers || {};
+
         if (sourceResolved === 'structures') {
             try {
                 const subQuery = { secret: process.env.CRON_SECRET };
                 if (limit) subQuery.limit = limit.toString();
 
-                await ingestStructures({ query: subQuery, headers: {}, url: '/' }, {
+                await ingestStructures({ query: subQuery, headers: proxyHeaders, url: '/' }, {
                     status: () => ({ json: (d) => mergeStats(d) })
                 });
             } catch (e) {
@@ -157,7 +137,7 @@ export default async function handler(req, res) {
                 const subQuery = { secret: process.env.CRON_SECRET };
                 if (limit) subQuery.limit = limit.toString();
 
-                await ingestAids({ query: subQuery, headers: {}, url: '/' }, {
+                await ingestAids({ query: subQuery, headers: proxyHeaders, url: '/' }, {
                     status: () => ({ json: (d) => mergeStats(d) })
                 });
             } catch (e) {

--- a/api/_utils/cronAuth.js
+++ b/api/_utils/cronAuth.js
@@ -1,0 +1,68 @@
+
+/**
+ * Helper to retrieve a header safely from Vercel Request or Node Request
+ */
+export function getHeader(req, name) {
+    if (!req) return undefined;
+    const n = name.toLowerCase();
+    const h = req.headers;
+
+    // Fetch/Edge style (Headers object)
+    if (h && typeof h.get === "function") {
+        return h.get(name) ?? h.get(n) ?? undefined;
+    }
+
+    // Node/Express style (Plain object)
+    if (h && typeof h === "object") {
+        return h[n] ?? h[name] ?? undefined;
+    }
+    return undefined;
+}
+
+/**
+ * Extract Bearer token from Authorization header
+ */
+export function getBearer(req) {
+    const h = getHeader(req, 'authorization');
+    if (!h) return null;
+    const m = /^Bearer\s+(.+)$/i.exec(h);
+    return m ? m[1].trim() : null;
+}
+
+/**
+ * Standardized Cron Authorization Check
+ * Accepts:
+ * 1. Authorization: Bearer <CRON_SECRET>
+ * 2. ?secret=<CRON_SECRET>
+ * 3. x-vercel-cron: 1
+ */
+export function isCronAuthorized(req) {
+    if (!process.env.CRON_SECRET) {
+        console.error("CRITICAL: CRON_SECRET is not defined in environment.");
+        return false;
+    }
+
+    // 1. Query Params (supports generic Node req or Vercel req.query)
+    let secretQuery = req.query?.secret;
+    if (!secretQuery && req.url) {
+        // Fallback parsing for manual calls or raw URLs
+        try {
+            const proto = getHeader(req, 'x-forwarded-proto') || 'http';
+            const host = getHeader(req, 'host') || 'localhost';
+            secretQuery = new URL(req.url, `${proto}://${host}`).searchParams.get('secret');
+        } catch (e) {
+            // ignore URL parse errors
+        }
+    }
+
+    // 2. Bearer Token
+    const bearer = getBearer(req);
+
+    // 3. Vercel Cron Header
+    const vercelCronHeader = getHeader(req, 'x-vercel-cron');
+
+    // Matching logic
+    const token = bearer || secretQuery;
+
+    return (token === process.env.CRON_SECRET) || (vercelCronHeader === '1');
+}

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -19,17 +19,30 @@ Ce document décrit les procédures de résolution d'incidents et de maintenance
 
 ### Cron Jobs en échec
 1. Vérifier `/api/admin/runs` pour voir les logs d'exécution.
-2. Si timeout, réduire le volume de données traité par batch.
-3. Déclencher manuellement via l'URL :
-   ```bash
-   # Run Structures (Limit default)
-   curl -X POST "https://.../api/cron/pipeline?source=structures" \
-     --header "Authorization: Bearer \$CRON_SECRET"
+2. Si timeout, réduire le volume de données traité### 3. Commandes Utiles
 
-   # Run Aids (via Alias 'demarches') - Mode Smoke (5 items)
-   curl -X POST "https://.../api/cron/pipeline?source=demarches&mode=smoke" \
-     --header "Authorization: Bearer \$CRON_SECRET"
+Pour déclencher le pipeline manuellement (Production ou Local) :
 
+Il y a 3 méthodes d'authentification supportées :
+1.  **Header Bearer** (Recommandé) : `-H "Authorization: Bearer <CRON_SECRET>"`
+2.  **Query Param** (Fallback) : `?secret=<CRON_SECRET>`
+3.  **Vercel Cron** (Automatique) : Header `x-vercel-cron: 1`
+
+#### Smoke Test (Vérification Rapide)
+```bash
+# Via Bearer Token
+curl -X POST "https://votre-url.net/api/cron/pipeline?source=structures&mode=smoke" \
+     -H "Authorization: Bearer $CRON_SECRET"
+
+# Via Query Param
+curl -X POST "https://votre-url.net/api/cron/pipeline?source=structures&mode=smoke&secret=$CRON_SECRET"
+```
+
+#### Ingestion Complète (Aides)
+```bash
+curl -X POST "https://votre-url.net/api/cron/pipeline?source=aides" \
+     -H "Authorization: Bearer $CRON_SECRET"
+```
    # Run RSS (via Alias 'actualites') - Safe Limit (Start with 50)
    # Note: Ajustez la limite si durationMs > 35s (Timeout à 50s)
    curl -X POST "https://.../api/cron/pipeline?source=actualites&limit=50" \

--- a/tests/integration/pipeline_routing.test.js
+++ b/tests/integration/pipeline_routing.test.js
@@ -51,6 +51,25 @@ describe('Cron Pipeline Routing', () => {
         expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
     });
 
+    it('should authorize via Bearer token', async () => {
+        const { req, res } = createMocks({ source: 'structures' }, { authorization: `Bearer ${CRON_SECRET}` });
+        const ingestStructures = (await import('../../api/_handlers/cron/ingest-structures.js')).default;
+
+        await pipelineHandler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(ingestStructures).toHaveBeenCalled();
+    });
+
+    it('should authorize via query param', async () => {
+        const { req, res } = createMocks({ source: 'structures', secret: CRON_SECRET });
+        // Clean mock
+        const ingestStructures = (await import('../../api/_handlers/cron/ingest-structures.js')).default;
+        ingestStructures.mockClear();
+
+        await pipelineHandler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+
     it('should return 400 if source is missing', async () => {
         const { req, res } = createMocks({ secret: CRON_SECRET });
         await pipelineHandler(req, res);


### PR DESCRIPTION
## Objectif
Fixer définitivement le problème "fetched=0" / 401 sur les ingesters (structures/aides) causé par une authentification incohérente entre le pipeline et les handlers spécialisés.

## Changements
- **Factorisation Auth**: Création de `api/_utils/cronAuth.js` qui standardise la vérification :
  1. Header `Authorization: Bearer ...`
  2. Query Param `?secret=...`
  3. Header `x-vercel-cron: 1`
- **Pipeline Update**: `api/_handlers/cron/pipeline.js` utilise maintenant cette vérification ET transmet les headers originaux aux sous-handlers (`ingest-structures`, `ingest-aids`) pour maintenir le contexte d'authentification.
- **Ingesters Update**: `ingest-structures.js` et `ingest-aids.js` utilisent maintenant `cronAuth` et acceptent enfin le Bearer token (via headers passés par pipeline).
- **Anti-Silent Failure**: Ajout de logs `console.warn` explicites si 0 items sont fetchés, incluant le status HTTP et le Content-Type pour faciliter le debug futur.
- **Tests**: Mise à jour des tests d'intégration pour valider les 3 méthodes d'auth et le routing.

## Validation
- **Tests Locaux**: `npm test` (Integration Tests) -> PASS (voir logs CI).
- **Preuve**: Voir tests ajoutés dans `tests/integration/pipeline_routing.test.js`.

Closes #P0-AUTH-FIX