### PR TITLE
fix(ui): polish header logo pill, nav active, and hero branding

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -54,9 +54,6 @@ export default function Home() {
       {/* Hero Section */}
       <section className="bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800 text-white py-16 md:py-24">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 text-center">
-          <div className="mb-8 flex justify-center">
-            <Logo variant="hero" />
-          </div>
           <h1 className="text-3xl md:text-5xl font-bold mb-6 leading-tight">
             Trouvez les aides et les services
             <br className="hidden md:block" />

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -203,18 +203,18 @@ export default function Layout({ children, currentPageName }) {
               {/* Mobile: Logo Icon Only */}
               <Link
                 to={createPageUrl('Home')}
-                className="sm:hidden flex items-center justify-center p-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 rounded-full bg-surface border border-border shadow-sm hover:shadow-md transition-shadow"
+                className="sm:hidden flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 rounded-lg"
                 aria-label="AccesDirectAide - Accueil"
               >
-                <Logo variant="icon" size={32} />
+                <Logo variant="icon" size={40} />
               </Link>
               {/* Desktop: Logo Full */}
               <Link
                 to={createPageUrl('Home')}
-                className="hidden sm:flex items-center px-4 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 rounded-full bg-surface border border-border shadow-sm hover:shadow-md transition-shadow gap-2"
+                className="hidden sm:flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 rounded-lg"
                 aria-label="AccesDirectAide - Accueil"
               >
-                <Logo variant="full" size={28} />
+                <Logo variant="full" size={40} />
               </Link>
             </div>
 
@@ -226,10 +226,10 @@ export default function Layout({ children, currentPageName }) {
                     <>
                       <Link
                         to={createPageUrl(item.page)}
-                        className={`flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2
+                        className={`flex items-center gap-1 px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 rounded-lg relative
                           ${currentPageName === item.page
-                            ? 'text-brand-primary bg-brand-highlight/10'
-                            : 'text-text-body hover:text-brand-primary hover:bg-surface'
+                            ? 'text-brand-primary after:absolute after:bottom-0 after:left-3 after:right-3 after:h-0.5 after:bg-brand-primary'
+                            : 'text-text-body hover:text-brand-primary hover:bg-brand-highlight/10'
                           }`}
                         aria-haspopup="menu"
                         aria-controls={`nav-${item.page.toLowerCase()}-menu`}
@@ -260,10 +260,10 @@ export default function Layout({ children, currentPageName }) {
                   ) : (
                     <Link
                       to={createPageUrl(item.page)}
-                      className={`flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2
+                      className={`flex items-center gap-1 px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 rounded-lg relative
                         ${currentPageName === item.page
-                          ? 'text-brand-primary bg-brand-highlight/10'
-                          : 'text-text-body hover:text-brand-primary hover:bg-surface'
+                          ? 'text-brand-primary after:absolute after:bottom-0 after:left-3 after:right-3 after:h-0.5 after:bg-brand-primary'
+                          : 'text-text-body hover:text-brand-primary hover:bg-brand-highlight/10'
                         }`}
                     >
                       {item.label}


### PR DESCRIPTION
What changed

Header: allège le “logo pill”, nav active plus discret (underline), focus visible clavier uniquement.

Home hero: suppression du logo dupliqué dans le hero.

How to verify

npm run lint && npm run typecheck && npm run build

Visuel : header = logo plus léger, “Accueil” souligné (pas de gros pill), hero = pas de logo dupliqué.

Accessibilité : tab dans le header → focus ring visible, pas de “layout shift”.

