### PR TITLE
P6-D Auto-migrations prod (prisma migrate deploy) + smoke runbook

### DIFF
--- a/docs/P6_GO_LIVE.md
+++ b/docs/P6_GO_LIVE.md
@@ -4,6 +4,23 @@
 
 Executer l'ingestion des actualites (RSS/Atom) en production via un endpoint cron securise, avec un scheduling Vercel, sans modifier la logique d'ingestion P5.
 
+## Prerequis (IMPORTANT)
+
+Si une PR introduit une migration Prisma (ex: nouvelle table `CronRun`), la prod doit appliquer les migrations avant que les endpoints ne puissent ecrire en DB.
+
+Ce repo fournit maintenant un build "safe" pour automatiser l'application des migrations en prod:
+
+- Script: `npm run vercel-build`
+- Comportement:
+  - `VERCEL_ENV=production` => `prisma migrate deploy` est execute pendant le build
+  - sinon => migrations skip (preview/dev)
+
+### Configuration Vercel
+
+Dans Vercel (Project Settings):
+
+- Build Command: `npm run vercel-build`
+
 ## Endpoint
 
 - `GET /api/cron/actualites`
@@ -49,6 +66,10 @@ Sur Vercel, configurez la "cron secret" (ou equivalent) pour que les executions 
    - Attendre la fin du run (TTL lock: 20 minutes)
    - Si besoin: verifier le backend KV (Upstash) ou redemarrer la stack
 
+4. `500 CronRun table missing` / Prisma "table does not exist"
+   - Cause: migrations Prisma pas appliquees en prod
+   - Fix: executer `npx prisma migrate deploy` sur la DB prod (voir `docs/RUNBOOK_MIGRATIONS.md`)
+
 ### Execution manuelle (debug)
 
 Exemples (ne pas coller de valeurs reelles dans les tickets ou PRs):
@@ -64,3 +85,14 @@ Ou via script local:
 node scripts/ingest-actualites.js --limit 5
 ```
 
+## Post-deploy smoke (prod)
+
+Script local (aucun secret en dur, utilise uniquement les variables du terminal):
+
+```bash
+export PROD_URL="https://www.accesdirectaide.fr"
+export CRON_SECRET="(dans ton terminal)"
+export ADMIN_TOKEN="(dans ton terminal)"
+
+npm run smoke:prod
+```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "vercel-build": "node scripts/vercel-build.mjs",
     "db:deploy": "prisma migrate deploy",
     "db:migrate": "prisma migrate deploy",
     "db:seed": "prisma db seed",
@@ -23,6 +24,7 @@
     "test:api": "node scripts/test-run.mjs tests/integration",
     "test:repeat": "node scripts/test-repeat.mjs",
     "test:e2e": "playwright test",
+    "smoke:prod": "node scripts/smoke-prod.mjs",
     "verify": "node scripts/verify-lot9a-routes.js && node scripts/verify-rdv.js && node scripts/verify-actualites.js && node scripts/verify-sitemap.js && node scripts/verify-robots.js",
     "guard:prisma": "node scripts/guard-prisma.js",
     "preview": "vite preview",

--- a/scripts/smoke-prod.mjs
+++ b/scripts/smoke-prod.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+/**
+ * Post-deploy smoke checks (prod).
+ *
+ * - No secrets are hardcoded.
+ * - Never prints env values (tokens, URLs, DSNs).
+ *
+ * Usage:
+ *   export PROD_URL="https://www.accesdirectaide.fr"
+ *   export CRON_SECRET="..."
+ *   export ADMIN_TOKEN="..."
+ *   npm run smoke:prod
+ */
+
+import { fetch } from 'undici';
+
+/**
+ * @param {string} label
+ * @param {string} url
+ * @param {{ headers?: Record<string, string> }=} options
+ */
+async function check(label, url, options = {}) {
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: options.headers || undefined,
+  });
+
+  // Try to capture minimal diagnostics without dumping arbitrary HTML.
+  let requestId = undefined;
+  try {
+    const text = await res.text();
+    const json = JSON.parse(text);
+    if (json && typeof json === 'object' && typeof json.requestId === 'string') requestId = json.requestId;
+  } catch {
+    // ignore
+  }
+
+  const status = res.status;
+  const ok = status >= 200 && status < 300;
+  const extra = requestId ? ` requestId=${requestId}` : '';
+
+  console.log(`[smoke] ${label}: HTTP=${status}${extra}`);
+  if (!ok) {
+    const err = new Error(`[smoke] ${label} failed (HTTP=${status})`);
+    err.statusCode = status;
+    throw err;
+  }
+}
+
+function requireEnv(name) {
+  const raw = process.env[name];
+  if (typeof raw === 'string' && raw.trim() !== '') return raw.trim();
+  return null;
+}
+
+async function main() {
+  const baseUrl = requireEnv('PROD_URL') || 'https://www.accesdirectaide.fr';
+  const cronSecret = requireEnv('CRON_SECRET');
+  const adminToken = requireEnv('ADMIN_TOKEN');
+
+  const missing = [];
+  if (!cronSecret) missing.push('CRON_SECRET');
+  if (!adminToken) missing.push('ADMIN_TOKEN');
+
+  if (missing.length > 0) {
+    console.error(`[smoke] MISSING: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  await check('health', `${baseUrl}/api/health`);
+  await check('cron.actualites', `${baseUrl}/api/cron/actualites`, {
+    headers: { Authorization: `Bearer ${cronSecret}` },
+  });
+  await check('admin.cron-runs', `${baseUrl}/api/admin/cron-runs?limit=10`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  });
+
+  console.log('[smoke] OK');
+}
+
+main().catch((err) => {
+  const status = typeof err?.statusCode === 'number' ? ` HTTP=${err.statusCode}` : '';
+  console.error(`[smoke] FAILED.${status}`);
+  process.exit(1);
+});
+

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * Vercel build entrypoint (safe).
+ *
+ * Goals:
+ * - Keep `npm run build` unchanged (still runs `vite build`).
+ * - Run Prisma migrations automatically in **production only**.
+ * - Never print environment values (DB URLs, tokens, DSNs, etc).
+ *
+ * Expected Vercel setup:
+ * - Build Command: `npm run vercel-build`
+ */
+
+import { execSync } from 'node:child_process';
+
+/**
+ * @param {string} cmd
+ */
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+const vercelEnv = String(process.env.VERCEL_ENV || '').trim() || 'unknown';
+const isProduction = vercelEnv === 'production';
+
+console.log(`[vercel-build] start (VERCEL_ENV=${vercelEnv})`);
+
+// Ensure Prisma client is generated (idempotent).
+run('npx prisma generate');
+
+if (isProduction) {
+  console.log('[vercel-build] production detected -> running prisma migrate deploy');
+  run('npx prisma migrate deploy');
+} else {
+  console.log('[vercel-build] skipping prisma migrate deploy (not production)');
+}
+
+// Build the frontend bundle.
+run('npm run build');
+
+console.log('[vercel-build] done');
+


### PR DESCRIPTION
## What
- Added `npm run vercel-build` to run `prisma migrate deploy` automatically in **production only** (guarded by `VERCEL_ENV=production`) without changing `npm run build`.
- Added `npm run smoke:prod` for post-deploy smoke checks (health + cron + admin cron-runs).
- Updated `docs/P6_GO_LIVE.md` with Vercel Build Command guidance + incident runbook.

## How To Test (Local)
- `npm run lint`
- `npm run typecheck`
- `npm run lint:strict:baseline`
- `npm run typecheck:strict:baseline`
- `npm test`
- `npm run build`
- `npx playwright test e2e/public-core.spec.js`

## Post-deploy smoke (Prod)
Set these in your terminal (no values in PR):
- `PROD_URL`
- `CRON_SECRET`
- `ADMIN_TOKEN`

Then run: `npm run smoke:prod`

## Notes
- Vercel Build Command should be set to: `npm run vercel-build`.
- No secrets committed ✅