### PR TITLE
fix(monitor): restore x-robots-tag on /api/monitor/* direct handlers

### DIFF
--- a/api/_handlers/monitor/core.js
+++ b/api/_handlers/monitor/core.js
@@ -3,6 +3,7 @@ import prisma from '../../_utils/prisma.js';
 import { kv } from '../../_utils/kv.js';
 import { env } from '../../_utils/env.js';
 import logger from '../../_utils/logger.js';
+import { applyNoIndex } from '../../_utils/robots.js';
 
 const TIMEOUT_MS = 2000;
 
@@ -73,6 +74,7 @@ export default async function handler(req, res) {
   res.setHeader('x-request-id', requestId);
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  applyNoIndex(res);
 
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed', requestId });

--- a/api/_handlers/monitor/cron-actualites.js
+++ b/api/_handlers/monitor/cron-actualites.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import prisma from '../../_utils/prisma.js';
 import { getActualitesCronFreshness } from '../../_utils/cron-freshness.js';
+import { applyNoIndex } from '../../_utils/robots.js';
 
 /**
  * Public uptime-friendly endpoint for external monitors.
@@ -21,6 +22,7 @@ export default async function handler(req, res) {
   res.setHeader('x-request-id', requestId);
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  applyNoIndex(res);
 
   return res.status(isFresh ? 200 : 503).json({
     ok: isFresh,
@@ -32,4 +34,3 @@ export default async function handler(req, res) {
     requestId,
   });
 }
-

--- a/api/_handlers/monitor/data-quality.js
+++ b/api/_handlers/monitor/data-quality.js
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import prisma from '../../_utils/prisma.js';
 import { env } from '../../_utils/env.js';
 import logger from '../../_utils/logger.js';
+import { applyNoIndex } from '../../_utils/robots.js';
 
 const TIMEOUT_MS = 2000;
 
@@ -51,6 +52,7 @@ export default async function handler(req, res) {
   res.setHeader('x-request-id', requestId);
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  applyNoIndex(res);
 
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed', requestId });

--- a/api/_handlers/monitor/ingestion-freshness.js
+++ b/api/_handlers/monitor/ingestion-freshness.js
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import prisma from '../../_utils/prisma.js';
 import { env } from '../../_utils/env.js';
 import logger from '../../_utils/logger.js';
+import { applyNoIndex } from '../../_utils/robots.js';
 
 const TIMEOUT_MS = 2000;
 
@@ -54,6 +55,7 @@ export default async function handler(req, res) {
   res.setHeader('x-request-id', requestId);
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  applyNoIndex(res);
 
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed', requestId });

--- a/tests/integration/p8b-monitor-core.test.js
+++ b/tests/integration/p8b-monitor-core.test.js
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import apiHandler from '../../api/index.js';
+import monitorCoreHandler from '../../api/monitor/core.js';
 import prisma from '../../api/_utils/prisma.js';
 import { kv } from '../../api/_utils/kv.js';
 
@@ -96,7 +96,7 @@ async function invokeApi(url, options = {}) {
     query: options.query,
   });
   const res = createRes();
-  await apiHandler(req, res);
+  await monitorCoreHandler(req, res);
   return res;
 }
 


### PR DESCRIPTION
## Why
Issue #196 reported a PROD smoke failure:
- `/api/monitor/core` returned `HTTP 200` but missing `x-robots-tag`.

Root cause: monitor endpoints are deployed as direct Vercel function entrypoints (`/api/monitor/*.js`) and do not always pass through `api/index.js` where noindex headers are centrally injected.

## What changed
- Added explicit `applyNoIndex(res)` in monitor handlers:
  - `api/_handlers/monitor/core.js`
  - `api/_handlers/monitor/data-quality.js`
  - `api/_handlers/monitor/ingestion-freshness.js`
  - `api/_handlers/monitor/cron-actualites.js`
- Updated monitor core integration test to invoke direct handler export (production-like path):
  - `tests/integration/p8b-monitor-core.test.js`

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run smoke:obs:prod` (current PROD still fails until this PR is deployed, expected)

## Security
- No secrets committed or logged.
- Response payloads unchanged except technical headers hardening.

Closes #196
