### PR TITLE
P0-09 — A11y E2E (Playwright + axe-core) + GitHub Action + artefacts

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,40 @@
+name: A11y E2E
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run A11y Tests
+        run: npm run test:a11y
+
+      - name: Upload Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-report
+          path: |
+            playwright-report/
+            test-results/
+            traces/
+          retention-days: 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "^9.19.0",
         "@flydotio/dockerfile": "^0.7.4",
         "@playwright/test": "^1.58.0",
@@ -1141,6 +1142,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:api": "node scripts/test-run.mjs tests/integration",
     "test:repeat": "node scripts/test-repeat.mjs",
     "test:e2e": "playwright test",
+    "test:a11y": "cross-env TEST_A11Y=1 playwright test --reporter=html",
     "smoke:prod": "node scripts/smoke-prod.mjs",
     "smoke:seo:prod": "node scripts/seo-smoke.mjs",
     "smoke:obs:prod": "node scripts/obs-smoke.mjs",
@@ -127,6 +128,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^9.19.0",
     "@flydotio/dockerfile": "^0.7.4",
     "@playwright/test": "^1.58.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,7 @@ const BASE_URL = REMOTE_BASE_URL || LOCAL_BASE_URL;
 const SHOULD_START_WEBSERVER = !!process.env.CI || !REMOTE_BASE_URL;
 
 export default defineConfig({
-  testDir: './e2e',
+  testDir: process.env.TEST_A11Y ? './tests/a11y' : './e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/tests/a11y/a11y.utils.ts
+++ b/tests/a11y/a11y.utils.ts
@@ -1,0 +1,23 @@
+import { Page, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+export async function expectNoA11yIssues(page: Page, options?: any) {
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    const filtered = accessibilityScanResults.violations.filter(
+        (violation) => violation.impact === 'critical' || violation.impact === 'serious'
+    );
+
+    if (filtered.length > 0) {
+        console.error(`Found ${filtered.length} a11y violations (critical/serious):`);
+        filtered.forEach((v) => {
+            console.error(`- [${v.impact}] ${v.id}: ${v.description}`);
+            v.nodes.forEach((node) => {
+                console.error(`  - Target: ${node.target.join(', ')}`);
+                console.error(`    Failure: ${node.failureSummary}`);
+            });
+        });
+    }
+
+    expect(filtered, "A11y violations (critical/serious)").toEqual([]);
+}

--- a/tests/a11y/home.spec.ts
+++ b/tests/a11y/home.spec.ts
@@ -1,0 +1,9 @@
+import { test } from '@playwright/test';
+import { expectNoA11yIssues } from './a11y.utils';
+
+test('Home page should have no critical or serious accessibility issues', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await page.waitForSelector('main', { state: 'attached' });
+    await expectNoA11yIssues(page);
+});

--- a/tests/a11y/listing-aides.spec.ts
+++ b/tests/a11y/listing-aides.spec.ts
@@ -1,0 +1,9 @@
+import { test } from '@playwright/test';
+import { expectNoA11yIssues } from './a11y.utils';
+
+test('Aides listing page should have no critical or serious accessibility issues', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/aides', { waitUntil: 'networkidle' });
+    await page.waitForSelector('main', { state: 'attached' });
+    await expectNoA11yIssues(page);
+});


### PR DESCRIPTION
# P0-09 — A11y E2E (Playwright + axe-core) + GitHub Action + artefacts

## Objectif
Mise en place d'une CI bloquante pour détecter les régressions d'accessibilité (A11y) majeures (`critical` et `serious`) via Playwright et `@axe-core/playwright`.

## Changements
- Ajout de `@axe-core/playwright`.
- Création du wrapper utilitaire `a11y.utils.ts` avec la logique d'assertion d'AxeBuilder.
- Implémentation de deux tests d'accessibilité E2E sur les routes réelles `/` (Home) et `/aides` (Listing Aides), avec sécurisation du rendu DOM (`waitForSelector('main')`).
- Implémentation du Github Action `.github/workflows/a11y.yml` :
  - Bloquant sur PR et push main.
  - Sauvegarde inconditionnelle des artefacts E2E (rapport HTML, traces).
- Ajout script `test:a11y` tout en respectant l'organisation stricte de Playwright existante (`testDir` dynamique dans `playwright.config.js` sans casser `e2e`).

Aucun fichier en dehors du périmètre strict n'a été modifié. L'échec du run de test initial montre que la CI fait bien son travail face aux dettes d'accessibilité pré-existantes.