### PR TITLE
P0-10 — A11y Fix : Color Contrast Violations

### DIFF
--- a/src/components/home/AssistantFeatureSection.jsx
+++ b/src/components/home/AssistantFeatureSection.jsx
@@ -16,7 +16,7 @@ export default function AssistantFeatureSection() {
           <div className="mt-8 flex flex-wrap gap-3">
             <Link
               to="/orientation"
-              className="rounded-xl bg-blue-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-400"
+              className="rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
             >
               Lancer le diagnostic
             </Link>

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -363,11 +363,11 @@ export default function Layout({ children, currentPageName }) {
               <div className="mb-6">
                 <Logo variant="full" tone="white" size={48} />
               </div>
-              <p className="text-white/80 text-sm mb-4">
+              <p className="text-white text-sm mb-4">
                 Un site non lucratif pour vous aider à trouver les aides,
                 les démarches et les structures d&apos;accompagnement près de chez vous.
               </p>
-              <p className="text-white/80 text-sm">
+              <p className="text-white text-sm">
                 Toutes les informations sont vérifiées et sourcées.
                 Zéro fake news, zéro approximation.
               </p>
@@ -381,7 +381,7 @@ export default function Layout({ children, currentPageName }) {
                   <li key={link.label + idx}>
                     <Link
                       to={link.href || createPageUrl(link.page)}
-                      className="text-white/70 hover:text-white text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-highlight focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary rounded"
+                      className="text-white hover:text-slate-200 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-highlight focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary rounded"
                     >
                       {link.label}
                     </Link>
@@ -398,7 +398,7 @@ export default function Layout({ children, currentPageName }) {
                   <li key={link.label + idx}>
                     <Link
                       to={link.href || createPageUrl(link.page)}
-                      className="text-white/70 hover:text-white text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-highlight focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary rounded"
+                      className="text-white hover:text-slate-200 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-highlight focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary rounded"
                     >
                       {link.label}
                     </Link>
@@ -408,7 +408,7 @@ export default function Layout({ children, currentPageName }) {
             </div>
           </div>
 
-          <div className="border-t border-white/20 mt-8 pt-8 text-center text-sm text-white/60">
+          <div className="border-t border-white/20 mt-8 pt-8 text-center text-sm text-white">
             <p>© {new Date().getFullYear()} AccesDirectAide. Site non lucratif.</p>
             <p className="mt-2">
               Territoire couvert : Alsace (Bas-Rhin, Haut-Rhin) et aides nationales.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -85,6 +85,14 @@ module.exports = {
 					ring: 'hsl(var(--sidebar-ring))'
 				},
 
+				// ✅ Core Brand tokens (from tokens.css)
+				brand: {
+					primary: 'rgb(var(--color-brand-primary) / <alpha-value>)',
+					secondary: 'rgb(var(--color-brand-secondary) / <alpha-value>)',
+					highlight: 'rgb(var(--color-brand-highlight) / <alpha-value>)',
+					background: 'rgb(var(--color-brand-background) / <alpha-value>)',
+				},
+
 				// ✅ Blueprint Trust tokens (namespaced to avoid collisions)
 				bt: {
 					ink: '#0B1220',


### PR DESCRIPTION
# P0-10: Fix A11y E2E Violations (Layout & Home)

## Objectif
Résoudre les problèmes de contraste de couleurs soulevés par la CI de sécurité Playwright + Axe-Core (P0-09) afin de valider à 100% l'accessibilité AA sur la `Home` et le layout global (Footer).

## Changements apportés
1. **`tailwind.config.js`** : Mappage officiel du dictionnaire des variables natives de la charte graphique (`brand` : `--color-brand-primary` etc.) afin de réparer les classes Tailwind inopérantes (`bg-brand-primary` ne rendait aucune couleur pour axe-core).
2. **`src/pages/Layout.jsx` (Footer)** : Retrait des opacités drastiques sur les paragraphes et les liens du footer (passage de `text-white/60`, `70`, `80` à `text-white` et `hover:text-slate-200`) pour rétablir un contraste largement supérieur aux 4.5:1 requis par défaut sur le fond bleu foncé du branding.
3. **`src/components/home/AssistantFeatureSection.jsx`** : Remplacement du bouton *Lancer le diagnostic* de `bg-blue-500` (qui échouait à 3.67:1 contre texte blanc) par `bg-blue-600` (5.5:1, validant l'accessibilité tout en gardant une esthétique native).

Tous les tests E2E A11y (`npm run test:a11y`) passent désormais au rouge 0 (vert) ! ✅