### PR TITLE
P0-11 — SEO prerender baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/prerender.mjs",
     "vercel-build": "node scripts/vercel-build.mjs",
     "db:status": "prisma migrate status",
     "db:deploy": "prisma migrate deploy",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   <url>
+      <loc>https://accesdirectaide.fr/</loc>
+      <changefreq>weekly</changefreq>
+      <priority>1.0</priority>
+   </url>
+   <url>
+      <loc>https://accesdirectaide.fr/aides</loc>
+      <changefreq>daily</changefreq>
+      <priority>0.8</priority>
+   </url>
+</urlset>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'vite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distPath = path.resolve(__dirname, '../dist');
+const serverOutDir = path.resolve(__dirname, '../dist/server');
+
+async function prerender() {
+    console.log("Starting SSG Prerender...");
+
+    // 1. Build the server bundle
+    await build({
+        build: {
+            ssr: 'src/entry-server.jsx',
+            outDir: 'dist/server',
+            emptyOutDir: true
+        },
+        ssr: { noExternal: true }
+    });
+
+    // 2. Load the exported render function and seo object
+    const serverPath = path.resolve(serverOutDir, 'entry-server.js');
+    const { render, seo } = await import(serverPath);
+
+    // 3. Read the client-built index.html as a template
+    const templatePath = path.resolve(distPath, 'index.html');
+    const template = fs.readFileSync(templatePath, 'utf-8');
+
+    // Routes to prerender
+    const routes = ['/', '/aides'];
+
+    for (const url of routes) {
+        try {
+            console.log(`Prerendering ${url} ...`);
+
+            // Render the app for this route
+            const appHtml = await render(url);
+
+            // Inject the rendered HTML
+            let html = template.replace(
+                '<div id="root"></div>',
+                `<div id="root">${appHtml}</div>`
+            );
+
+            // Inject SEO Meta
+            const routeSeo = seo[url] || {
+                title: "AccesDirectAide",
+                description: "Accéder à vos droits simplement."
+            };
+
+            html = html.replace(
+                /<title>.*?<\/title>/,
+                `<title>${routeSeo.title}</title>`
+            );
+
+            const descTag = `<meta name="description" content="${routeSeo.description}" />`;
+            if (html.includes('<meta name="description"')) {
+                html = html.replace(/<meta name="description" content=".*?"\s*\/?>/, descTag);
+            } else {
+                html = html.replace('</head>', `  ${descTag}\n</head>`);
+            }
+
+            // Determine output path
+            const isHome = url === '/';
+            const outputDir = isHome ? distPath : path.resolve(distPath, url.substring(1));
+
+            if (!isHome) {
+                fs.mkdirSync(outputDir, { recursive: true });
+            }
+
+            const filePath = path.resolve(outputDir, 'index.html');
+            fs.writeFileSync(filePath, html);
+            console.log(`✓ Prerendered ${filePath}`);
+        } catch (e) {
+            console.error(`Error prerendering ${url}:`, e);
+            process.exit(1);
+        }
+    }
+
+    // 4. Cleanup the temporary server bundle
+    fs.rmSync(serverOutDir, { recursive: true, force: true });
+    console.log("SSG Prerender complete.");
+}
+
+prerender();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,12 +6,12 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from "@/lib/queryClient";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
-function App() {
+function App({ url }) {
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <HelmetProvider>
-          <Pages />
+          <Pages url={url} />
           <Toaster />
         </HelmetProvider>
       </QueryClientProvider>

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderToPipeableStream } from 'react-dom/server';
+import { Writable } from 'node:stream';
+import App from './App.jsx';
+export { seo } from './lib/seo.ts';
+
+export function render(url) {
+    return new Promise((resolve, reject) => {
+        let html = '';
+        const writable = new Writable({
+            write(chunk, encoding, callback) {
+                html += chunk;
+                callback();
+            }
+        });
+
+        const { pipe } = renderToPipeableStream(
+            <React.StrictMode>
+                <App url={url} />
+            </React.StrictMode>,
+            {
+                onAllReady() {
+                    pipe(writable);
+                },
+                onError(error) {
+                    reject(error);
+                }
+            }
+        );
+
+        writable.on('finish', () => resolve(html));
+    });
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,4 @@
+export const seo = {
+    "/": { title: "AccesDirectAide — Accéder à vos droits simplement", description: "Trouvez rapidement aides, démarches et structures fiables près de chez vous." },
+    "/aides": { title: "Aides — AccesDirectAide", description: "Liste d’aides et dispositifs, avec preuve de fraîcheur des sources." },
+} as const;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from "react";
-import { BrowserRouter as Router, Route, Routes, useLocation, Navigate, useParams } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter, Route, Routes, useLocation, Navigate, useParams } from 'react-router-dom';
 import { frontendEnv } from "@/config/env";
 
 // [LAZY LOADED PAGES]
@@ -328,10 +328,18 @@ function PagesContent() {
     );
 }
 
-export default function Pages() {
+export default function Pages({ url }) {
+    const isServer = typeof window === 'undefined' || url !== undefined;
+    if (isServer) {
+        return (
+            <MemoryRouter initialEntries={[url || '/']}>
+                <PagesContent />
+            </MemoryRouter>
+        );
+    }
     return (
-        <Router>
+        <BrowserRouter>
             <PagesContent />
-        </Router>
+        </BrowserRouter>
     );
 }

--- a/test-ssr.mjs
+++ b/test-ssr.mjs
@@ -1,0 +1,14 @@
+import { build } from 'vite';
+
+async function run() {
+    try {
+        const { render } = await import('./dist/server/entry-server.js');
+        console.log("RENDER IMPORT SUCCESS", typeof render);
+
+        const homepage = await render('');
+        console.log(homepage.substring(0, 150));
+    } catch (e) {
+        console.error("OVERALL ERR:", e);
+    }
+}
+run();

--- a/vite.config.js
+++ b/vite.config.js
@@ -214,7 +214,7 @@ export default defineConfig({
       "api/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
       "scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
     ],
-    exclude: ["node_modules", "dist", ".vercel", "e2e", "**/*.spec.js"],
+    exclude: ["node_modules", "dist", ".vercel", "e2e", "**/*.spec.js", "**/*.spec.ts"],
     setupFiles: ["./tests/setup-env.js"],
   },
 });


### PR DESCRIPTION
## P0-11 — SEO prerender baseline

Implémentation d'un pre-render (SSG) hyper-minimaliste sans Next ni Vike, via l'API programmatique de Vite.

### Modifications apportées
1. Modification du composant `App.jsx` et `Pages.jsx` pour exposer la possibilité de forcer l'usage du `MemoryRouter` lors du SSR.
2. Ajout de `src/lib/seo.ts` pour centraliser les métadonnées (title, description).
3. Ajout d'un script `scripts/prerender.mjs` appelé après `vite build` permettant de builder le bundle SSR, de rendre en HTML les routes `/` et `/aides`, de l'injecter dans la coquille `dist/index.html` (générée par le build public) avec les bons `meta`.
4. Stubs `public/robots.txt` et `public/sitemap.xml` (avec les règles attendues par les tests).
5. Exclusion de `**/*.spec.ts` dans `vite.config.js` pour empêcher vitest de lancer des specs Playwright lors du `npm run test`.

### Pre-flight checks validés
- ✅ `npm ci`
- ✅ `npm run lint`
- ✅ `npm run typecheck`
- ✅ `npm test`
- ✅ `npm run build`
- ✅ Vérification de la présence des balises `<h1>` sur `dist/index.html` et `dist/aides/index.html`.