### PR TITLE
P1-01 — Home HeroSearch (tokens + a11y)

### DIFF
--- a/src/components/organisms/HeroSearch.stories.tsx
+++ b/src/components/organisms/HeroSearch.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MemoryRouter } from "react-router-dom";
+import HeroSearch from "./HeroSearch";
+
+const meta = {
+    title: "Organisms/HeroSearch",
+    component: HeroSearch,
+    tags: ["autodocs"],
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        ),
+    ],
+} satisfies Meta<typeof HeroSearch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default state with standard copy */
+export const Default: Story = {};
+
+/** Simulates a narrow mobile viewport (375 px) */
+export const Mobile: Story = {
+    decorators: [
+        (Story) => (
+            <div style={{ maxWidth: 375 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+/** Stress-test with long title and placeholder */
+export const LongText: Story = {
+    args: {
+        title:
+            "Trouvez rapidement une aide adaptée à votre situation personnelle, familiale et professionnelle.",
+        subtitle:
+            "Aides financières, démarches administratives, structures d\u2019accompagnement social et médico-social\u00a0— toutes les informations sourcées et mises à jour.",
+        placeholder:
+            "Allocation adultes handicapés, aide personnalisée au logement, complémentaire santé solidaire\u2026",
+    },
+};

--- a/src/components/organisms/HeroSearch.tsx
+++ b/src/components/organisms/HeroSearch.tsx
@@ -1,0 +1,73 @@
+import type { FormEvent } from "react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export interface HeroSearchProps {
+    /** Main heading text */
+    title?: string;
+    /** Subtitle / secondary text */
+    subtitle?: string;
+    /** Placeholder for the search input */
+    placeholder?: string;
+}
+
+export default function HeroSearch({
+    title = "Trouvez une aide rapidement.",
+    subtitle = "Aides, démarches, structures\u00a0— informations sourcées.",
+    placeholder = "Logement, santé, handicap\u2026",
+}: HeroSearchProps) {
+    const navigate = useNavigate();
+    const [query, setQuery] = useState("");
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const trimmed = query.trim();
+        if (trimmed) {
+            navigate(`/aides?q=${encodeURIComponent(trimmed)}`);
+        } else {
+            navigate("/aides");
+        }
+    };
+
+    return (
+        <section className="bg-background py-16 sm:py-24">
+            <div className="mx-auto max-w-3xl px-4 text-center sm:px-6">
+                <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
+                    {title}
+                </h1>
+
+                <p className="mt-4 text-base text-muted-foreground sm:text-lg">
+                    {subtitle}
+                </p>
+
+                <form
+                    onSubmit={handleSubmit}
+                    className="mt-8 flex flex-col gap-3 sm:flex-row"
+                    role="search"
+                >
+                    <div className="relative flex-1">
+                        <label className="sr-only" htmlFor="hero-search">
+                            Rechercher une aide
+                        </label>
+                        <Search
+                            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                            aria-hidden="true"
+                        />
+                        <Input
+                            id="hero-search"
+                            type="search"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder={placeholder}
+                            className="pl-10"
+                        />
+                    </div>
+                    <Button type="submit">Rechercher</Button>
+                </form>
+            </div>
+        </section>
+    );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 
 import SEO from '@/components/SEO';
-import HeroSection from '@/components/home/HeroSection';
+import HeroSearch from '@/components/organisms/HeroSearch';
 import QuickAccessSection from '@/components/home/QuickAccessSection';
 import CategoriesSection from '@/components/home/CategoriesSection';
 import AssistantFeatureSection from '@/components/home/AssistantFeatureSection';
@@ -19,7 +19,7 @@ export default function Home() {
         schema={schema}
       />
 
-      <HeroSection />
+      <HeroSearch />
       <QuickAccessSection />
       <CategoriesSection />
       <AssistantFeatureSection />


### PR DESCRIPTION
## P1-01 — Home HeroSearch (tokens + a11y)

### Résumé
Remplace `HeroSection` dans `Home.jsx` par un nouveau composant **`HeroSearch`** (organism) qui :
- Utilise **uniquement des design tokens** (`bg-background`, `text-foreground`, `text-muted-foreground`) — zéro hex, zéro palette Tailwind brute
- Offre une **accessibilité complète** : label sr-only, focus-visible, enter-to-submit via `<form>`
- Navigue vers `/aides?q=...` au submit

### Fichiers modifiés/créés
| Fichier | Action |
|---------|--------|
| `src/components/organisms/HeroSearch.tsx` | **NEW** — Composant organism |
| `src/components/organisms/HeroSearch.stories.tsx` | **NEW** — 3 stories (Default, Mobile, LongText) |
| `src/pages/Home.jsx` | **MODIFY** — Import HeroSearch au lieu de HeroSection |

### Route listing détectée
`/aides` avec paramètre `?q=` — confirmé dans `src/pages/Aides.jsx` ligne 64.

### Preflight
| Commande | Statut |
|----------|--------|
| `npm ci` | ✅ |
| `npm run lint` | ✅ (0 errors) |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ (86 suites, 370 tests) |
| `npm run build` | ✅ |
| `npm run build-storybook` | ✅ |
| `npm run test-storybook` | ✅ (8 suites, 29 tests, 0 a11y violations) |