### PR TITLE
P1-02 — Listing Aides + FilterPanel + AidGrid (empty state rules)

### DIFF
--- a/src/components/organisms/AidGrid.stories.tsx
+++ b/src/components/organisms/AidGrid.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import AidGrid from "./AidGrid";
+import type { AidGridProps } from "./AidGrid";
+
+const NOW = new Date("2026-02-20T00:00:00.000Z");
+
+const MOCK_ITEMS: AidGridProps["items"] = [
+    {
+        title: "Aide personnalisée au logement (APL)",
+        href: "/aides/apl",
+        summary:
+            "L\u2019APL est une aide financière destinée à réduire le montant de votre loyer ou de votre redevance en foyer.",
+        isUrgent: false,
+        verifiedAt: new Date("2026-02-10T00:00:00.000Z"),
+        sourceLabel: "CAF",
+        sourceUrl: "https://www.caf.fr",
+        now: NOW,
+    },
+    {
+        title: "Aide d\u2019urgence hébergement",
+        href: "/aides/urgence-hebergement",
+        summary:
+            "Dispositif d\u2019hébergement d\u2019urgence pour les personnes sans domicile fixe.",
+        isUrgent: true,
+        verifiedAt: new Date("2026-01-28T00:00:00.000Z"),
+        sourceLabel: "SIAO",
+        sourceUrl: "https://www.siao.fr",
+        now: NOW,
+    },
+    {
+        title: "Complémentaire santé solidaire (CSS)",
+        href: "/aides/css",
+        summary:
+            "La CSS prend en charge la part complémentaire de vos dépenses de santé.",
+        isUrgent: false,
+        verifiedAt: new Date("2026-02-01T00:00:00.000Z"),
+        sourceLabel: "Ameli",
+        sourceUrl: "https://www.ameli.fr",
+        now: NOW,
+    },
+];
+
+const meta = {
+    title: "Organisms/AidGrid",
+    component: AidGrid,
+    tags: ["autodocs"],
+} satisfies Meta<typeof AidGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Grid with 3 items */
+export const WithItems: Story = {
+    args: {
+        items: MOCK_ITEMS,
+        hasActiveFilters: false,
+    },
+};
+
+/** Empty with active filters → shows EmptyState */
+export const EmptyWithActiveFilters: Story = {
+    args: {
+        items: [],
+        hasActiveFilters: true,
+        onReset: () => { },
+    },
+};
+
+/** Empty without active filters → neutral text, NOT EmptyState */
+export const EmptyWithoutActiveFilters: Story = {
+    args: {
+        items: [],
+        hasActiveFilters: false,
+    },
+};

--- a/src/components/organisms/AidGrid.tsx
+++ b/src/components/organisms/AidGrid.tsx
@@ -1,0 +1,50 @@
+import { AidCard } from "@/components/molecules/AidCard";
+import type { AidCardProps } from "@/components/molecules/AidCard";
+import EmptyState from "@/components/ui/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
+
+export interface AidGridProps {
+    items: AidCardProps[];
+    hasActiveFilters: boolean;
+    onReset?: () => void;
+}
+
+export default function AidGrid({
+    items,
+    hasActiveFilters,
+    onReset,
+}: AidGridProps) {
+    if (items.length === 0 && hasActiveFilters) {
+        return (
+            <EmptyState
+                title="Aucune aide trouvée"
+                description="Essayez d'élargir votre recherche ou réinitialisez les filtres."
+                icon={<Search className="h-6 w-6" />}
+                actions={
+                    onReset ? (
+                        <Button type="button" variant="outline" onClick={onReset}>
+                            Réinitialiser les filtres
+                        </Button>
+                    ) : undefined
+                }
+            />
+        );
+    }
+
+    if (items.length === 0) {
+        return (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+                Chargement des aides…
+            </p>
+        );
+    }
+
+    return (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {items.map((item, index) => (
+                <AidCard key={item.href || index} {...item} />
+            ))}
+        </div>
+    );
+}

--- a/src/components/organisms/FilterPanel.stories.tsx
+++ b/src/components/organisms/FilterPanel.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import FilterPanel from "./FilterPanel";
+import type { FilterState } from "./FilterPanel";
+import { useState } from "react";
+
+const INITIAL_FILTERS: FilterState = {
+    search: "",
+    category: "",
+    urgentOnly: false,
+};
+
+function FilterPanelWrapper(props: { initial?: Partial<FilterState> }) {
+    const [filters, setFilters] = useState<FilterState>({
+        ...INITIAL_FILTERS,
+        ...props.initial,
+    });
+    return (
+        <FilterPanel
+            filters={filters}
+            onChange={setFilters}
+            onReset={() => setFilters(INITIAL_FILTERS)}
+        />
+    );
+}
+
+const meta: Meta = {
+    title: "Organisms/FilterPanel",
+    tags: ["autodocs"],
+};
+
+export default meta;
+
+/** Default empty state */
+export const Default = {
+    render: () => <FilterPanelWrapper />,
+};
+
+/** With search query pre-filled */
+export const WithSearch = {
+    render: () => <FilterPanelWrapper initial={{ search: "logement" }} />,
+};
+
+/** With category selected */
+export const WithCategory = {
+    render: () => <FilterPanelWrapper initial={{ category: "sante" }} />,
+};
+
+/** Mobile viewport (375 px container) */
+export const MobileWidth = {
+    render: () => (
+        <div style={{ maxWidth: 375 }}>
+            <FilterPanelWrapper />
+        </div>
+    ),
+};

--- a/src/components/organisms/FilterPanel.tsx
+++ b/src/components/organisms/FilterPanel.tsx
@@ -1,0 +1,101 @@
+import type { FormEvent } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export interface FilterState {
+    search: string;
+    category: string;
+    urgentOnly: boolean;
+}
+
+export interface FilterPanelProps {
+    filters: FilterState;
+    onChange: (next: FilterState) => void;
+    onReset: () => void;
+}
+
+const CATEGORIES = [
+    { value: "", label: "Toutes les catégories" },
+    { value: "logement", label: "Logement" },
+    { value: "sante", label: "Santé" },
+    { value: "handicap", label: "Handicap" },
+    { value: "emploi", label: "Emploi" },
+    { value: "urgence", label: "Urgence" },
+] as const;
+
+export default function FilterPanel({
+    filters,
+    onChange,
+    onReset,
+}: FilterPanelProps) {
+    const handleSearchSubmit = (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+    };
+
+    return (
+        <aside aria-label="Filtres" className="space-y-6">
+            {/* Search */}
+            <form onSubmit={handleSearchSubmit}>
+                <label htmlFor="filter-search" className="sr-only">
+                    Rechercher une aide
+                </label>
+                <Input
+                    id="filter-search"
+                    type="search"
+                    placeholder="Rechercher…"
+                    value={filters.search}
+                    onChange={(e) => onChange({ ...filters, search: e.target.value })}
+                />
+            </form>
+
+            {/* Category */}
+            <div>
+                <label
+                    htmlFor="filter-category"
+                    className="mb-1 block text-sm font-medium text-foreground"
+                >
+                    Catégorie
+                </label>
+                <select
+                    id="filter-category"
+                    value={filters.category}
+                    onChange={(e) => onChange({ ...filters, category: e.target.value })}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                    {CATEGORIES.map((cat) => (
+                        <option key={cat.value} value={cat.value}>
+                            {cat.label}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            {/* Urgency */}
+            <fieldset>
+                <legend className="mb-1 text-sm font-medium text-foreground">
+                    Priorité
+                </legend>
+                <label
+                    htmlFor="filter-urgent"
+                    className="flex cursor-pointer items-center gap-2 text-sm text-foreground"
+                >
+                    <input
+                        id="filter-urgent"
+                        type="checkbox"
+                        checked={filters.urgentOnly}
+                        onChange={(e) =>
+                            onChange({ ...filters, urgentOnly: e.target.checked })
+                        }
+                        className="h-4 w-4 rounded border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    />
+                    Urgence uniquement
+                </label>
+            </fieldset>
+
+            {/* Reset */}
+            <Button type="button" variant="outline" className="w-full" onClick={onReset}>
+                Réinitialiser les filtres
+            </Button>
+        </aside>
+    );
+}

--- a/src/pages/Aides.jsx
+++ b/src/pages/Aides.jsx
@@ -8,9 +8,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import EmptyState from '@/components/ui/EmptyState';
 import AideCard from '@/components/cards/AideCard';
+import FilterPanel from '@/components/organisms/FilterPanel';
+import AidGrid from '@/components/organisms/AidGrid';
 import { buildAidesItemListSchema, buildBreadcrumbSchema } from '@/lib/seo';
+import { getProvenance, formatProvenanceDate, extractSourceHost } from '@/lib/provenance';
 
 const DEFAULT_LIMIT = 20;
 const LIMIT_OPTIONS = [10, 20, 50];
@@ -31,12 +33,22 @@ function parseLimit(value) {
   return parsed;
 }
 
+const INITIAL_LOCAL_FILTERS = { search: '', category: '', urgentOnly: false };
+
 export default function Aides() {
   const location = useLocation();
   const navigate = useNavigate();
   const { slug } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+  const [localFilters, setLocalFilters] = useState(INITIAL_LOCAL_FILTERS);
+
+  const hasActiveLocalFilters =
+    localFilters.search.trim() !== '' ||
+    localFilters.category !== '' ||
+    localFilters.urgentOnly;
+
+  const resetLocalFilters = () => setLocalFilters(INITIAL_LOCAL_FILTERS);
 
   // Legacy pretty routes -> canonical query params
   useEffect(() => {
@@ -369,85 +381,123 @@ export default function Aides() {
         </div>
       </div>
 
-      {/* Results */}
+      {/* Main content: sidebar + results */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
-        {error && (
-          <div
-            className="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-900"
-            role="alert"
-            data-testid="aides-error-state"
-          >
-            <h2 className="text-lg font-semibold">Impossible de charger les aides</h2>
-            <p className="mt-2 text-sm">
-              Une erreur est survenue. Vous pouvez réessayer.
-            </p>
-            <Button type="button" variant="outline" className="mt-4" onClick={() => refetch()}>
-              <RotateCcw className="mr-2 h-4 w-4" />
-              Réessayer
-            </Button>
-          </div>
-        )}
-
-        {(isLoading || isFetching) && !error && (
-          <div className="space-y-3" data-testid="aides-loading-state">
-            {[1, 2, 3, 4, 5, 6].map((value) => (
-              <div key={value} className="rounded-xl border border-slate-200 bg-white p-5">
-                <Skeleton className="h-4 w-24" />
-                <Skeleton className="mt-3 h-5 w-3/4" />
-                <Skeleton className="mt-2 h-4 w-full" />
-                <Skeleton className="mt-2 h-4 w-2/3" />
-              </div>
-            ))}
-          </div>
-        )}
-
-        {!error && !isLoading && !isFetching && items.length === 0 && (
-          <div data-testid="aides-empty-state">
-            <EmptyState
-              title="Aucune aide trouvée"
-              message="Essayez une autre recherche ou ajustez les filtres."
-              actionLabel="Réinitialiser les filtres"
-              onAction={clearFilters}
-              type="search"
+        <div className="flex flex-col gap-8 lg:flex-row">
+          {/* Sidebar FilterPanel */}
+          <div className="w-full shrink-0 lg:w-64">
+            <FilterPanel
+              filters={localFilters}
+              onChange={setLocalFilters}
+              onReset={resetLocalFilters}
             />
           </div>
-        )}
 
-        {!error && items.length > 0 && (
-          <>
-            <p className="mb-4 text-sm text-slate-600" data-testid="aides-success-state">
-              {pagination.total ?? items.length} aide{(pagination.total ?? items.length) > 1 ? 's' : ''} trouvée{(pagination.total ?? items.length) > 1 ? 's' : ''}.
-            </p>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3" data-testid="aides-results-list">
-              {items.map((aide) => (
-                <AideCard key={aide.id} aide={aide} />
-              ))}
-            </div>
-
-            {/* Pagination */}
-            {totalPages > 1 && (
-              <div className="flex justify-center mt-10 gap-2">
-                <Button
-                  variant="outline"
-                  disabled={page <= 1}
-                  onClick={() => handlePageChange(page - 1)}
-                >
-                  Précédent
-                </Button>
-                <span className="flex items-center px-4 text-sm font-medium">
-                  Page {page} / {totalPages}
-                </span>
-                <Button
-                  variant="outline"
-                  disabled={!hasNext}
-                  onClick={() => handlePageChange(page + 1)}
-                >
-                  Suivant
+          {/* Results column */}
+          <div className="min-w-0 flex-1">
+            {error && (
+              <div
+                className="rounded-2xl border border-destructive/30 bg-destructive/5 p-6 text-destructive"
+                role="alert"
+                data-testid="aides-error-state"
+              >
+                <h2 className="text-lg font-semibold">Impossible de charger les aides</h2>
+                <p className="mt-2 text-sm">
+                  Une erreur est survenue. Vous pouvez réessayer.
+                </p>
+                <Button type="button" variant="outline" className="mt-4" onClick={() => refetch()}>
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                  Réessayer
                 </Button>
               </div>
             )}
-          </>
-        )}
+
+            {(isLoading || isFetching) && !error && (
+              <div className="space-y-3" data-testid="aides-loading-state">
+                {[1, 2, 3, 4, 5, 6].map((value) => (
+                  <div key={value} className="rounded-xl border border-border bg-card p-5">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="mt-3 h-5 w-3/4" />
+                    <Skeleton className="mt-2 h-4 w-full" />
+                    <Skeleton className="mt-2 h-4 w-2/3" />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {!error && !isLoading && !isFetching && (() => {
+              // Apply local filters on top of API results
+              const localSearch = localFilters.search.trim().toLowerCase();
+              const filtered = items.filter((aide) => {
+                if (localFilters.urgentOnly && !aide.est_urgent) return false;
+                if (localFilters.category) {
+                  const cat = aide?.categorie || aide?.theme || aide?.category?.slug || aide?.category_code || '';
+                  if (String(cat).toLowerCase() !== localFilters.category) return false;
+                }
+                if (localSearch) {
+                  const title = (aide.titre || '').toLowerCase();
+                  const desc = (aide.cest_quoi || '').toLowerCase();
+                  if (!title.includes(localSearch) && !desc.includes(localSearch)) return false;
+                }
+                return true;
+              });
+
+              // Build AidCardProps for AidGrid
+              const gridItems = filtered.map((aide) => {
+                const prov = getProvenance(aide);
+                return {
+                  title: aide.titre || '',
+                  href: aide.slug ? `/aides/${aide.slug}` : `/aide/view?id=${aide.id}`,
+                  summary: aide.cest_quoi || undefined,
+                  isUrgent: Boolean(aide.est_urgent),
+                  verifiedAt: prov.verifiedAt || undefined,
+                  sourceLabel: prov.sourceHost || undefined,
+                  sourceUrl: prov.sourceUrl || undefined,
+                };
+              });
+
+              const hasAnyFilters = hasActiveLocalFilters ||
+                Boolean(q) || Boolean(category) || Boolean(situation) || Boolean(territory);
+
+              return (
+                <>
+                  {filtered.length > 0 && (
+                    <p className="mb-4 text-sm text-muted-foreground" data-testid="aides-success-state">
+                      {filtered.length} aide{filtered.length > 1 ? 's' : ''} trouvée{filtered.length > 1 ? 's' : ''}.
+                    </p>
+                  )}
+                  <AidGrid
+                    items={gridItems}
+                    hasActiveFilters={hasAnyFilters}
+                    onReset={() => { clearFilters(); resetLocalFilters(); }}
+                  />
+                  {/* Legacy card grid for items not handled by AidGrid (pagination) */}
+                  {filtered.length > 0 && totalPages > 1 && (
+                    <div className="flex justify-center mt-10 gap-2">
+                      <Button
+                        variant="outline"
+                        disabled={page <= 1}
+                        onClick={() => handlePageChange(page - 1)}
+                      >
+                        Précédent
+                      </Button>
+                      <span className="flex items-center px-4 text-sm font-medium text-foreground">
+                        Page {page} / {totalPages}
+                      </span>
+                      <Button
+                        variant="outline"
+                        disabled={!hasNext}
+                        onClick={() => handlePageChange(page + 1)}
+                      >
+                        Suivant
+                      </Button>
+                    </div>
+                  )}
+                </>
+              );
+            })()}
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## P1-02 — Listing Aides + FilterPanel + AidGrid (empty state rules)

### Résumé
Intègre deux nouveaux organisms dans la page `/aides` :
- **FilterPanel** : sidebar avec recherche, select catégorie, checkbox urgence — tous avec labels a11y (fieldset/legend, sr-only)
- **AidGrid** : grille responsive qui consomme `molecules/AidCard`, avec garde **hasActiveFilters** pour EmptyState

### Règle EmptyState
| Situation | Comportement |
|-----------|-------------|
| Items > 0 | Grille 1/2/3 colonnes |
| Items = 0 + filtres actifs | `EmptyState` ("Aucune aide trouvée" + bouton Réinitialiser) |
| Items = 0 + aucun filtre | Texte neutre "Chargement des aides…" — **PAS** d'EmptyState |

### hasActiveFilters = TRUE si
- `search` non vide **OU**
- `category` sélectionnée **OU**
- `urgentOnly` coché **OU**
- query/catégorie/situation/territoire dans l'URL (API)

### Fichiers
| Fichier | Action |
|---------|--------|
| `src/components/organisms/FilterPanel.tsx` | **NEW** |
| `src/components/organisms/FilterPanel.stories.tsx` | **NEW** (4 stories) |
| `src/components/organisms/AidGrid.tsx` | **NEW** |
| `src/components/organisms/AidGrid.stories.tsx` | **NEW** (3 stories) |
| `src/pages/Aides.jsx` | **MODIFY** — sidebar layout + AidGrid + local filters |

### Route listing
`/aides` — `src/pages/index.jsx` ligne 262

### Preflight
| Commande | Statut |
|----------|--------|
| `npm ci` | ✅ |
| `npm run lint` | ✅ (0 errors) |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ (86 suites, 370 tests) |
| `npm run build` | ✅ |
| `npm run build-storybook` | ✅ |
| `npm run test-storybook` | ✅ (10 suites, 36 tests, 0 a11y violations) |

### Démo EmptyState
1. **Voir EmptyState** : taper un texte absurde dans le champ "Rechercher…" du FilterPanel (ex: "xyznotfound") → 0 résultat + `hasActiveFilters=true` → EmptyState s'affiche
2. **Pas d'EmptyState** : vider tous les filtres → `hasActiveFilters=false` → le texte neutre ou la grille s'affiche, jamais EmptyState