### PR TITLE
P1-03 — Aide detail layout (sections + chunking + trust)

### DIFF
--- a/src/components/organisms/AidDetailLayout.stories.tsx
+++ b/src/components/organisms/AidDetailLayout.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import AidDetailLayout from "./AidDetailLayout";
+import type { AidDetailLayoutProps } from "./AidDetailLayout";
+
+const NOW = new Date("2026-02-20T00:00:00.000Z");
+
+const BASE_SECTIONS: AidDetailLayoutProps["sections"] = [
+    {
+        id: "cest-quoi",
+        title: "C\u2019est quoi\u00a0?",
+        content: (
+            <p>
+                L&apos;APL est une aide financière destinée à réduire le montant de votre
+                loyer. Elle est versée directement au bailleur et déduite de votre loyer
+                mensuel. Le montant dépend de vos ressources, de la composition de votre
+                foyer et du lieu de votre logement.
+            </p>
+        ),
+    },
+    {
+        id: "pour-qui",
+        title: "Pour qui\u00a0?",
+        content: (
+            <ul className="list-disc space-y-1 pl-5">
+                <li>Locataires d&apos;un logement conventionné</li>
+                <li>Résidents en foyer ou résidence sociale</li>
+                <li>Accédants à la propriété (sous conditions)</li>
+            </ul>
+        ),
+    },
+    {
+        id: "documents",
+        title: "Documents nécessaires",
+        collapsible: true,
+        content: (
+            <ul className="list-disc space-y-1 pl-5">
+                <li>Pièce d&apos;identité en cours de validité</li>
+                <li>Avis d&apos;imposition (N-2)</li>
+                <li>Bail ou attestation de loyer</li>
+                <li>RIB</li>
+                <li>Justificatif de situation familiale</li>
+            </ul>
+        ),
+    },
+    {
+        id: "comment-faire",
+        title: "Comment faire\u00a0?",
+        collapsible: true,
+        content: (
+            <ol className="list-decimal space-y-2 pl-5">
+                <li>
+                    Rendez-vous sur le site de la CAF ou de la MSA selon votre régime.
+                </li>
+                <li>
+                    Créez un compte ou connectez-vous à votre espace personnel.
+                </li>
+                <li>Remplissez le formulaire de demande en ligne.</li>
+                <li>
+                    Transmettez les justificatifs demandés (bail, avis d&apos;imposition).
+                </li>
+                <li>Suivez l&apos;avancement de votre dossier depuis votre espace.</li>
+            </ol>
+        ),
+    },
+];
+
+const meta = {
+    title: "Organisms/AidDetailLayout",
+    component: AidDetailLayout,
+    tags: ["autodocs"],
+} satisfies Meta<typeof AidDetailLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default — verified recently */
+export const Default: Story = {
+    args: {
+        title: "Aide personnalisée au logement (APL)",
+        summary:
+            "Réduisez votre loyer grâce à cette aide versée directement à votre bailleur.",
+        isUrgent: false,
+        verifiedAt: new Date("2026-02-15T00:00:00.000Z"),
+        sourceLabel: "CAF",
+        sourceUrl: "https://www.caf.fr/allocataires/droits-et-prestations/s-informer-sur-les-aides/logement-et-cadre-de-vie/les-aides-personnelles-au-logement",
+        now: NOW,
+        sections: BASE_SECTIONS,
+        primaryCta: {
+            label: "Faire ma demande",
+            href: "https://www.caf.fr/allocataires/mes-services-en-ligne/faire-une-demande-de-prestation",
+        },
+        secondaryCta: {
+            label: "Simuler mes droits",
+            href: "https://www.caf.fr/allocataires/mes-services-en-ligne/faire-une-simulation",
+        },
+        backHref: "/aides",
+    },
+};
+
+/** Urgent + stale verification date */
+export const UrgentAndStale: Story = {
+    args: {
+        ...Default.args,
+        title: "Aide d\u2019urgence hébergement",
+        summary:
+            "Dispositif d\u2019hébergement d\u2019urgence pour les personnes sans domicile fixe.",
+        isUrgent: true,
+        verifiedAt: new Date("2025-06-01T00:00:00.000Z"),
+        sourceLabel: "SIAO",
+        sourceUrl: "https://www.siao.fr",
+        now: NOW,
+        sections: BASE_SECTIONS,
+    },
+};
+
+/** No verification date — FreshnessTag hidden via unknownBehavior=hide */
+export const UnknownDate: Story = {
+    args: {
+        ...Default.args,
+        title: "Prime d\u2019activité",
+        summary:
+            "La prime d\u2019activité complète les revenus des travailleurs modestes.",
+        verifiedAt: null,
+        sourceLabel: "CAF",
+        sourceUrl: undefined,
+        now: NOW,
+        sections: BASE_SECTIONS,
+    },
+};
+
+/** Mobile width (375 px) */
+export const MobileWidth: Story = {
+    args: {
+        ...Default.args,
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ maxWidth: 375 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/src/components/organisms/AidDetailLayout.tsx
+++ b/src/components/organisms/AidDetailLayout.tsx
@@ -1,0 +1,168 @@
+import type { ReactNode } from "react";
+import { FreshnessTag } from "@/components/molecules/FreshnessTag";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, ExternalLink, ChevronDown } from "lucide-react";
+
+export interface AidSection {
+    id: string;
+    title: string;
+    content: ReactNode;
+    /** If true, rendered inside a native disclosure (details/summary) */
+    collapsible?: boolean;
+}
+
+export interface AidDetailLayoutProps {
+    title: string;
+    summary?: string;
+    isUrgent?: boolean;
+    verifiedAt?: Date | string | null;
+    sourceLabel?: string;
+    sourceUrl?: string;
+    now?: Date;
+    sections: AidSection[];
+    primaryCta?: { label: string; href: string };
+    secondaryCta?: { label: string; href: string };
+    backHref?: string;
+}
+
+export default function AidDetailLayout({
+    title,
+    summary,
+    isUrgent,
+    verifiedAt,
+    sourceLabel,
+    sourceUrl,
+    now,
+    sections,
+    primaryCta,
+    secondaryCta,
+    backHref = "/aides",
+}: AidDetailLayoutProps) {
+    const openSections = sections.filter((s) => !s.collapsible);
+    const collapsibleSections = sections.filter((s) => s.collapsible);
+
+    return (
+        <div className="mx-auto max-w-3xl space-y-8 px-4 py-8 sm:px-6">
+            {/* Back link */}
+            <a
+                href={backHref}
+                className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+            >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                Retour aux aides
+            </a>
+
+            {/* Header */}
+            <header className="space-y-4">
+                <div className="flex flex-wrap items-start gap-2">
+                    <h1 className="text-2xl font-bold leading-tight text-foreground sm:text-3xl">
+                        {title}
+                    </h1>
+                    {isUrgent && (
+                        <Badge variant="destructive" className="shrink-0">
+                            Urgent
+                        </Badge>
+                    )}
+                </div>
+
+                {summary && (
+                    <p className="text-base leading-relaxed text-muted-foreground">
+                        {summary}
+                    </p>
+                )}
+
+                <FreshnessTag
+                    verifiedAt={verifiedAt}
+                    now={now}
+                    sourceLabel={sourceLabel}
+                    sourceUrl={sourceUrl}
+                    unknownBehavior="hide"
+                />
+            </header>
+
+            {/* CTAs */}
+            {(primaryCta || secondaryCta) && (
+                <nav aria-label="Actions" className="flex flex-wrap gap-3">
+                    {primaryCta && (
+                        <a
+                            href={primaryCta.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground ring-offset-background hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        >
+                            {primaryCta.label}
+                            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                        </a>
+                    )}
+                    {secondaryCta && (
+                        <a
+                            href={secondaryCta.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        >
+                            {secondaryCta.label}
+                            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                        </a>
+                    )}
+                </nav>
+            )}
+
+            {/* Always-open sections */}
+            {openSections.map((section) => (
+                <div key={section.id}>
+                    <h2
+                        id={`section-${section.id}`}
+                        className="mb-3 text-lg font-semibold text-foreground"
+                    >
+                        {section.title}
+                    </h2>
+                    <div className="text-sm leading-relaxed text-muted-foreground">
+                        {section.content}
+                    </div>
+                </div>
+            ))}
+
+            {/* Collapsible sections — native <details>/<summary> */}
+            {collapsibleSections.map((section) => (
+                <details
+                    key={section.id}
+                    className="group rounded-lg border border-border bg-card"
+                >
+                    <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-4 text-lg font-semibold text-foreground hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg [&::-webkit-details-marker]:hidden">
+                        <span>{section.title}</span>
+                        <ChevronDown
+                            className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180"
+                            aria-hidden="true"
+                        />
+                    </summary>
+                    <div className="px-4 pb-4 text-sm leading-relaxed text-muted-foreground">
+                        {section.content}
+                    </div>
+                </details>
+            ))}
+
+            {/* Source / provenance footer */}
+            {sourceUrl && (
+                <footer className="border-t border-border pt-6">
+                    <a
+                        href={sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 text-sm font-medium text-foreground underline underline-offset-4 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+                    >
+                        Consulter la source officielle
+                        <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                </footer>
+            )}
+            {!sourceUrl && sourceLabel && (
+                <footer className="border-t border-border pt-6">
+                    <p className="text-sm text-muted-foreground">
+                        Source : {sourceLabel}
+                    </p>
+                </footer>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## P1-03 — Page détail Aide + sections + chunking (tokens + a11y)

### Résumé
Nouveau composant **`AidDetailLayout`** (organism) — layout de page détail aide avec :
- **Header** : H1, Badge Urgent, FreshnessTag (`unknownBehavior="hide"` → jamais "Non renseigné")
- **CTAs** : liens `<a>` stylés tokens (pas de `Button asChild` → évite violation `nested-interactive`)
- **Sections ouvertes** (H2) : "C'est quoi ?" et "Pour qui ?"
- **Sections collapsibles** (`<details>/<summary>` natif) : "Documents nécessaires" et "Comment faire ?"
- **Footer source** : lien "Consulter la source officielle" ou label muted

### Route existante
`/aides/:slug` — `src/pages/AideDetail.jsx` (non modifié, route existante dans `index.jsx`)

### Fichiers
| Fichier | Action |
|---------|--------|
| `src/components/organisms/AidDetailLayout.tsx` | **NEW** |
| `src/components/organisms/AidDetailLayout.stories.tsx` | **NEW** (4 stories) |

### A11y
- ✅ H1 → H2 (pas de saut)
- ✅ `aria-hidden` sur icônes décoratives
- ✅ `aria-label` sur nav CTAs
- ✅ `target="_blank" rel="noopener noreferrer"` sur liens externes
- ✅ Focus-visible sur tous les interactifs
- ✅ Pas de `nested-interactive` (CTA = `<a>` pur, pas `Button asChild`)
- ✅ FreshnessTag `unknownBehavior="hide"` → zéro "Non renseigné"

### Stories
| Story | Vérifie |
|-------|---------|
| Default | Vérifié récemment, 2 CTAs, 4 sections |
| UrgentAndStale | Badge Urgent + date stale (warning) |
| UnknownDate | verifiedAt=null → FreshnessTag masqué |
| MobileWidth | 375px, chunking et CTAs |

### Preflight
| Commande | Statut |
|----------|--------|
| `npm ci` | ✅ |
| `npm run lint` | ✅ (0 errors) |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ (86 suites, 370 tests) |
| `npm run build` | ✅ |
| `npm run build-storybook` | ✅ |
| `npm run test-storybook` | ✅ (11 suites, 40 tests, 0 a11y violations) |

### Vérification
1. **Headings** : H1 → H2, pas de skip
2. **Chunking** : sections courtes + "Documents"/"Comment faire" collapsibles (`<details>`)
3. **Pas de "Non renseigné"** : FreshnessTag masqué quand date inconnue