### PR TITLE
P1-04 — FALC v1 toggle + rules + stories

### DIFF
--- a/src/components/features/falc/FalcToggle.stories.tsx
+++ b/src/components/features/falc/FalcToggle.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import FalcToggle from "./FalcToggle";
+import { useState } from "react";
+import type { ContentVariant } from "@/lib/falc";
+
+function FalcToggleWrapper(props: {
+    enabled: boolean;
+    initial?: ContentVariant;
+}) {
+    const [value, setValue] = useState<ContentVariant>(
+        props.initial ?? "standard",
+    );
+    return (
+        <FalcToggle enabled={props.enabled} value={value} onChange={setValue} />
+    );
+}
+
+const meta: Meta = {
+    title: "Features/FALC/Toggle",
+    tags: ["autodocs"],
+};
+
+export default meta;
+
+/** Toggle enabled, starting in standard mode */
+export const EnabledStandard = {
+    render: () => <FalcToggleWrapper enabled initial="standard" />,
+};
+
+/** Toggle enabled, starting in FALC mode */
+export const EnabledFalc = {
+    render: () => <FalcToggleWrapper enabled initial="falc" />,
+};
+
+/** Toggle disabled — FALC unavailable */
+export const DisabledUnavailable = {
+    render: () => <FalcToggleWrapper enabled={false} initial="standard" />,
+};

--- a/src/components/features/falc/FalcToggle.tsx
+++ b/src/components/features/falc/FalcToggle.tsx
@@ -1,0 +1,59 @@
+import type { ContentVariant } from "@/lib/falc";
+
+export interface FalcToggleProps {
+    /** Whether FALC content is available */
+    enabled: boolean;
+    /** Current variant */
+    value: ContentVariant;
+    /** Called when the user toggles */
+    onChange: (next: ContentVariant) => void;
+}
+
+export default function FalcToggle({
+    enabled,
+    value,
+    onChange,
+}: FalcToggleProps) {
+    const isActive = value === "falc";
+
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-3">
+                <button
+                    type="button"
+                    role="switch"
+                    aria-checked={isActive}
+                    aria-label="Version facile à lire"
+                    disabled={!enabled}
+                    onClick={() => onChange(isActive ? "standard" : "falc")}
+                    className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+                    style={{
+                        backgroundColor: isActive
+                            ? "hsl(var(--primary))"
+                            : "hsl(var(--muted))",
+                    }}
+                >
+                    <span
+                        className="pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform duration-200"
+                        style={{
+                            transform: isActive ? "translateX(1.25rem)" : "translateX(0)",
+                        }}
+                    />
+                </button>
+                <span className="text-sm font-medium text-foreground">
+                    Version facile à lire
+                </span>
+            </div>
+
+            {enabled ? (
+                <p className="text-xs text-muted-foreground">
+                    Simplifie le texte, sans changer les informations importantes.
+                </p>
+            ) : (
+                <p className="text-xs text-muted-foreground">
+                    Version facile à lire indisponible pour cette fiche.
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/features/falc/falc.rules.md
+++ b/src/components/features/falc/falc.rules.md
@@ -1,0 +1,56 @@
+# Règles d'écriture FALC (Facile à Lire et à Comprendre)
+
+## Phrases
+
+- **Une idée par phrase.**
+- Phrases courtes : 12 mots maximum.
+- Voix active. Pas de passif.
+- Sujet → verbe → complément.
+
+## Mots
+
+- Utilisez des mots simples et courants.
+- Si un mot technique est obligatoire, expliquez-le juste après.
+  - Exemple : « Le SIAO (service qui gère les demandes d'hébergement) »
+- Évitez les abréviations. Écrivez le mot complet.
+
+## Titres
+
+- Titres courts et clairs.
+- Formulez en question quand c'est possible.
+  - ✅ « C'est quoi ? » plutôt que ❌ « Description générale de la prestation. »
+
+## Listes
+
+- Utilisez des listes à puces.
+- Chaque puce = une information.
+- Pas de sous-listes imbriquées.
+
+## Liens
+
+- Décrivez l'action du lien.
+  - ✅ « Télécharger le formulaire de demande »
+  - ❌ « Cliquez ici »
+
+## Exemples Avant / Après
+
+### Exemple 1
+
+**Avant :**
+> L'aide personnalisée au logement est une prestation sociale versée par la CAF sous conditions de ressources afin de réduire la charge locative des ménages modestes occupant un logement conventionné.
+
+**Après (FALC) :**
+> L'APL est une aide pour payer votre loyer.
+> La CAF verse cette aide.
+> Vous devez avoir des revenus modestes.
+> Votre logement doit être conventionné (un type de logement validé par l'État).
+
+### Exemple 2
+
+**Avant :**
+> La demande doit être effectuée en ligne via le téléservice dédié, accessible depuis l'espace personnel de l'allocataire.
+
+**Après (FALC) :**
+> Faites votre demande sur internet.
+> Connectez-vous à votre compte CAF.
+> Remplissez le formulaire en ligne.

--- a/src/components/organisms/AidDetailFalc.stories.tsx
+++ b/src/components/organisms/AidDetailFalc.stories.tsx
@@ -1,0 +1,185 @@
+import type { Meta } from "@storybook/react";
+import { useState } from "react";
+import AidDetailLayout from "./AidDetailLayout";
+import type { AidDetailLayoutProps, AidSection } from "./AidDetailLayout";
+import FalcToggle from "@/components/features/falc/FalcToggle";
+import type { ContentVariant, FalcContent } from "@/lib/falc";
+import { hasFalc, getVariantContent } from "@/lib/falc";
+
+const NOW = new Date("2026-02-20T00:00:00.000Z");
+
+/* ──── Standard content ──── */
+const STANDARD_SECTIONS: Array<{ id: string; title: string; content: string }> =
+    [
+        {
+            id: "cest-quoi",
+            title: "C\u2019est quoi\u00a0?",
+            content:
+                "L\u2019APL est une aide financière destinée à réduire le montant de votre loyer. Elle est versée directement au bailleur et déduite de votre loyer mensuel. Le montant dépend de vos ressources, de la composition de votre foyer et du lieu de votre logement.",
+        },
+        {
+            id: "pour-qui",
+            title: "Pour qui\u00a0?",
+            content:
+                "Locataires d\u2019un logement conventionné, résidents en foyer ou résidence sociale, accédants à la propriété sous conditions.",
+        },
+        {
+            id: "documents",
+            title: "Documents nécessaires",
+            content:
+                "Pièce d\u2019identité en cours de validité, avis d\u2019imposition (N-2), bail ou attestation de loyer, RIB, justificatif de situation familiale.",
+        },
+        {
+            id: "comment-faire",
+            title: "Comment faire\u00a0?",
+            content:
+                "Rendez-vous sur le site de la CAF. Créez un compte ou connectez-vous. Remplissez le formulaire de demande en ligne. Transmettez les justificatifs demandés.",
+        },
+    ];
+
+/* ──── FALC content ──── */
+const FALC_CONTENT: FalcContent = {
+    title: "Aide pour payer votre loyer (APL)",
+    summary: "L\u2019APL est une aide. Elle sert à payer votre loyer.",
+    sections: [
+        {
+            id: "cest-quoi",
+            title: "C\u2019est quoi\u00a0?",
+            text: [
+                "L\u2019APL est une aide pour payer votre loyer.",
+                "La CAF verse cette aide.",
+                "Le montant dépend de vos revenus.",
+            ],
+        },
+        {
+            id: "pour-qui",
+            title: "Pour qui\u00a0?",
+            text: [
+                "Vous louez un logement conventionné.",
+                "Vous vivez en foyer.",
+                "Vous achetez un logement (sous conditions).",
+            ],
+        },
+        {
+            id: "documents",
+            title: "Documents nécessaires",
+            text: [
+                "Votre pièce d\u2019identité.",
+                "Votre avis d\u2019impôts.",
+                "Votre bail (contrat de location).",
+                "Votre RIB (coordonnées bancaires).",
+            ],
+        },
+        {
+            id: "comment-faire",
+            title: "Comment faire\u00a0?",
+            text: [
+                "Allez sur le site de la CAF.",
+                "Créez un compte.",
+                "Remplissez le formulaire.",
+                "Envoyez vos documents.",
+            ],
+        },
+    ],
+};
+
+/* ──── Helper to build AidSection[] from variant ──── */
+function toAidSections(
+    raw: Array<{ id: string; title: string; content: string }>,
+    collapsibleIds: string[] = ["documents", "comment-faire"],
+): AidSection[] {
+    return raw.map((s) => ({
+        id: s.id,
+        title: s.title,
+        content: s.content,
+        collapsible: collapsibleIds.includes(s.id),
+    }));
+}
+
+/* ──── Story wrapper ──── */
+function AidDetailWithFalc(props: {
+    falcContent: FalcContent | null;
+    layoutProps: Omit<AidDetailLayoutProps, "sections">;
+}) {
+    const falcAvailable = hasFalc(props.falcContent);
+    const [variant, setVariant] = useState<ContentVariant>("standard");
+
+    const resolved = getVariantContent({
+        variant,
+        standard: { title: props.layoutProps.title, summary: props.layoutProps.summary, sections: STANDARD_SECTIONS },
+        falc: props.falcContent,
+    });
+
+    const sections = toAidSections(resolved.sections);
+
+    return (
+        <div className="space-y-0">
+            <div className="mx-auto max-w-3xl px-4 pt-8 sm:px-6">
+                <FalcToggle
+                    enabled={falcAvailable}
+                    value={variant}
+                    onChange={setVariant}
+                />
+            </div>
+            <AidDetailLayout
+                {...props.layoutProps}
+                title={resolved.title}
+                summary={resolved.summary}
+                sections={sections}
+            />
+        </div>
+    );
+}
+
+const meta: Meta = {
+    title: "Organisms/AidDetailLayout/FALC",
+    tags: ["autodocs"],
+};
+
+export default meta;
+
+/** FALC available — user can toggle between standard and FALC */
+export const WithFalc = {
+    render: () => (
+        <AidDetailWithFalc
+            falcContent={FALC_CONTENT}
+            layoutProps={{
+                title: "Aide personnalisée au logement (APL)",
+                summary:
+                    "Réduisez votre loyer grâce à cette aide versée directement à votre bailleur.",
+                isUrgent: false,
+                verifiedAt: new Date("2026-02-15T00:00:00.000Z"),
+                sourceLabel: "CAF",
+                sourceUrl: "https://www.caf.fr",
+                now: NOW,
+                primaryCta: {
+                    label: "Faire ma demande",
+                    href: "https://www.caf.fr/allocataires/mes-services-en-ligne/faire-une-demande-de-prestation",
+                },
+            }}
+        />
+    ),
+};
+
+/** FALC not available — toggle disabled + message */
+export const WithoutFalc = {
+    render: () => (
+        <AidDetailWithFalc
+            falcContent={null}
+            layoutProps={{
+                title: "Complémentaire santé solidaire (CSS)",
+                summary:
+                    "La CSS prend en charge la part complémentaire de vos dépenses de santé.",
+                isUrgent: false,
+                verifiedAt: new Date("2026-02-01T00:00:00.000Z"),
+                sourceLabel: "Ameli",
+                sourceUrl: "https://www.ameli.fr",
+                now: NOW,
+                primaryCta: {
+                    label: "Faire ma demande",
+                    href: "https://www.ameli.fr",
+                },
+            }}
+        />
+    ),
+};

--- a/src/lib/falc.ts
+++ b/src/lib/falc.ts
@@ -1,0 +1,66 @@
+/** Content variant: standard or FALC (Facile à Lire et à Comprendre) */
+export type ContentVariant = "standard" | "falc";
+
+/** FALC-specific content block */
+export interface FalcSection {
+    id: string;
+    title: string;
+    text: string | string[];
+}
+
+/** FALC content for an aide */
+export interface FalcContent {
+    title?: string;
+    summary?: string;
+    sections?: FalcSection[];
+}
+
+/** Returns true if meaningful FALC content exists */
+export function hasFalc(content?: FalcContent | null): boolean {
+    if (!content) return false;
+    return !!(
+        content.title ||
+        content.summary ||
+        (content.sections && content.sections.length > 0)
+    );
+}
+
+export interface VariantContentArgs {
+    variant: ContentVariant;
+    standard: {
+        title: string;
+        summary?: string;
+        sections: Array<{ id: string; title: string; content: string }>;
+    };
+    falc?: FalcContent | null;
+}
+
+/**
+ * Returns the content to display based on the selected variant.
+ * Falls back to standard if FALC is unavailable.
+ */
+export function getVariantContent(args: VariantContentArgs) {
+    const { variant, standard, falc } = args;
+
+    if (variant === "falc" && hasFalc(falc)) {
+        const falcSections = (falc!.sections ?? []).map((s) => ({
+            id: s.id,
+            title: s.title,
+            content: Array.isArray(s.text) ? s.text.join("\n") : s.text,
+        }));
+
+        return {
+            variant: "falc" as const,
+            title: falc!.title ?? standard.title,
+            summary: falc!.summary ?? standard.summary,
+            sections: falcSections.length > 0 ? falcSections : standard.sections,
+        };
+    }
+
+    return {
+        variant: "standard" as const,
+        title: standard.title,
+        summary: standard.summary,
+        sections: standard.sections,
+    };
+}


### PR DESCRIPTION
## P1-04 — FALC v1 (toggle + règles + stories)

### Résumé
Première brique FALC (Facile à Lire et à Comprendre) :
- **`src/lib/falc.ts`** — types + utilitaires : `ContentVariant`, `FalcContent`, `hasFalc()`, `getVariantContent()`
- **`FalcToggle.tsx`** — switch accessible `role="switch"` + `aria-checked` + `aria-label`
- **`falc.rules.md`** — runbook d'écriture FALC (phrases courtes, voix active, exemples Avant/Après)
- **Stories** — FalcToggle (3) + AidDetailLayout/FALC intégré (2)

### Comportement
| Situation | Toggle | Message |
|-----------|--------|---------|
| FALC dispo | Actif | "Simplifie le texte, sans changer les informations importantes." |
| FALC indispo | Désactivé | "Version facile à lire indisponible pour cette fiche." |

### Fichiers
| Fichier | Action |
|---------|--------|
| `src/lib/falc.ts` | **NEW** — types + hasFalc + getVariantContent |
| `src/components/features/falc/FalcToggle.tsx` | **NEW** — switch accessible |
| `src/components/features/falc/FalcToggle.stories.tsx` | **NEW** — 3 stories |
| `src/components/features/falc/falc.rules.md` | **NEW** — runbook écriture |
| `src/components/organisms/AidDetailFalc.stories.tsx` | **NEW** — 2 stories (WithFalc, WithoutFalc) |

### A11y
- ✅ `role="switch"` + `aria-checked` + `aria-label`
- ✅ `focus-visible:ring-2 ring-ring ring-offset-background`
- ✅ `disabled` quand FALC indisponible (opacity-50, cursor-not-allowed)
- ✅ Pas de "Non renseigné" — message neutre explicite

### Message "indisponible"
Visible dans story `Features/FALC/Toggle > DisabledUnavailable` et `Organisms/AidDetailLayout/FALC > WithoutFalc`.
Texte exact : *"Version facile à lire indisponible pour cette fiche."*

### Preflight
| Commande | Statut |
|----------|--------|
| `npm ci` | ✅ |
| `npm run lint` | ✅ (0 errors) |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ (86 suites, 370 tests) |
| `npm run build` | ✅ |
| `npm run build-storybook` | ✅ |
| `npm run test-storybook` | ✅ (13 suites, 45 tests, 0 a11y violations) |