### PR TITLE
P1-05 — Trust surface (provenance + dates) unified

### DIFF
--- a/src/components/organisms/ProvenancePanel.stories.tsx
+++ b/src/components/organisms/ProvenancePanel.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ProvenancePanel from "./ProvenancePanel";
+
+const NOW = new Date("2026-02-20T00:00:00.000Z");
+
+const meta = {
+    title: "Organisms/ProvenancePanel",
+    component: ProvenancePanel,
+    tags: ["autodocs"],
+} satisfies Meta<typeof ProvenancePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Fresh — all data present */
+export const FreshComplete: Story = {
+    args: {
+        verifiedAt: new Date("2026-02-15T00:00:00.000Z"),
+        collectedAt: new Date("2026-02-18T00:00:00.000Z"),
+        sourceLabel: "CAF",
+        sourceUrl: "https://www.caf.fr",
+        now: NOW,
+    },
+};
+
+/** Stale — old verification date */
+export const StaleComplete: Story = {
+    args: {
+        verifiedAt: new Date("2025-06-01T00:00:00.000Z"),
+        collectedAt: new Date("2026-01-10T00:00:00.000Z"),
+        sourceLabel: "SIAO",
+        sourceUrl: "https://www.siao.fr",
+        now: NOW,
+    },
+};
+
+/** Unknown — both dates null, policy=label → "Date inconnue" */
+export const UnknownDates: Story = {
+    args: {
+        verifiedAt: null,
+        collectedAt: null,
+        sourceLabel: "Ameli",
+        sourceUrl: "https://www.ameli.fr",
+        now: NOW,
+        policy: { missingDate: "label" },
+    },
+};
+
+/** Unknown — both dates null, policy=hide → lines hidden */
+export const UnknownDatesHidden: Story = {
+    args: {
+        verifiedAt: null,
+        collectedAt: null,
+        sourceLabel: "MSA",
+        sourceUrl: "https://www.msa.fr",
+        now: NOW,
+        policy: { missingDate: "hide" },
+    },
+};
+
+/** No source URL — sourceLabel only (muted text) */
+export const NoSourceUrl: Story = {
+    args: {
+        verifiedAt: new Date("2026-02-10T00:00:00.000Z"),
+        collectedAt: new Date("2026-02-12T00:00:00.000Z"),
+        sourceLabel: "Mairie de Strasbourg",
+        now: NOW,
+    },
+};

--- a/src/components/organisms/ProvenancePanel.tsx
+++ b/src/components/organisms/ProvenancePanel.tsx
@@ -1,0 +1,115 @@
+import { getFreshnessStatus, type FreshnessStatus } from "@/lib/freshness";
+import {
+    resolveDateDisplay,
+    DEFAULT_TRUST_POLICY,
+    type TrustDisplayPolicy,
+} from "@/lib/trust";
+import { ExternalLink, ShieldCheck, ShieldAlert, ShieldQuestion } from "lucide-react";
+
+export interface ProvenancePanelProps {
+    verifiedAt?: Date | string | null;
+    collectedAt?: Date | string | null;
+    sourceLabel?: string;
+    sourceUrl?: string;
+    status?: FreshnessStatus;
+    policy?: TrustDisplayPolicy;
+    now?: Date;
+    /** Heading level — use "h2" on detail page, "h3" in sidebar */
+    as?: "h2" | "h3";
+}
+
+const STATUS_CONFIG: Record<
+    FreshnessStatus,
+    { icon: typeof ShieldCheck; label: string }
+> = {
+    fresh: {
+        icon: ShieldCheck,
+        label: "Source vérifiée récemment",
+    },
+    stale: {
+        icon: ShieldAlert,
+        label: "Vérification ancienne",
+    },
+    unknown: {
+        icon: ShieldQuestion,
+        label: "Statut de vérification inconnu",
+    },
+};
+
+export default function ProvenancePanel({
+    verifiedAt,
+    collectedAt,
+    sourceLabel,
+    sourceUrl,
+    status,
+    policy = DEFAULT_TRUST_POLICY,
+    now,
+    as: Heading = "h2",
+}: ProvenancePanelProps) {
+    const computedStatus =
+        status ?? getFreshnessStatus(verifiedAt, now ?? new Date());
+    const cfg = STATUS_CONFIG[computedStatus];
+    const StatusIcon = cfg.icon;
+
+    const verifiedDisplay = resolveDateDisplay(verifiedAt, policy.missingDate);
+    const collectedDisplay = resolveDateDisplay(collectedAt, policy.missingDate);
+
+    const hasDateRows = verifiedDisplay !== null || collectedDisplay !== null;
+    const hasSourceRow = !!(sourceUrl || sourceLabel);
+
+    return (
+        <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+            <div className="flex items-center gap-2">
+                <StatusIcon
+                    className="h-5 w-5 text-muted-foreground"
+                    aria-hidden="true"
+                />
+                <Heading className="text-sm font-semibold text-foreground">
+                    Provenance et fraîcheur
+                </Heading>
+            </div>
+
+            <p className="text-xs font-medium text-muted-foreground">{cfg.label}</p>
+
+            {hasDateRows && (
+                <dl className="space-y-2 text-sm">
+                    {verifiedDisplay !== null && (
+                        <div className="flex justify-between">
+                            <dt className="text-muted-foreground">Dernière vérification</dt>
+                            <dd className="font-medium text-foreground">
+                                {verifiedDisplay}
+                            </dd>
+                        </div>
+                    )}
+                    {collectedDisplay !== null && (
+                        <div className="flex justify-between">
+                            <dt className="text-muted-foreground">Dernière collecte</dt>
+                            <dd className="font-medium text-foreground">
+                                {collectedDisplay}
+                            </dd>
+                        </div>
+                    )}
+                </dl>
+            )}
+
+            {sourceUrl && (
+                <div className="pt-1">
+                    <a
+                        href={sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline underline-offset-4 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+                    >
+                        Consulter la source officielle
+                        <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                    </a>
+                </div>
+            )}
+            {!sourceUrl && sourceLabel && (
+                <p className="text-sm text-muted-foreground">
+                    Source : {sourceLabel}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/lib/trust.ts
+++ b/src/lib/trust.ts
@@ -1,0 +1,43 @@
+/**
+ * Centralised "missing data" policy for trust surface.
+ * SSOT: never show "Non renseigné".
+ */
+
+export type MissingDatePolicy = "label" | "hide";
+
+export interface TrustDisplayPolicy {
+    /** How to handle missing dates: "label" shows "Date inconnue", "hide" omits the line */
+    missingDate: MissingDatePolicy;
+}
+
+export const DEFAULT_TRUST_POLICY: TrustDisplayPolicy = {
+    missingDate: "label",
+};
+
+/** Label to display when a date is missing and policy is "label" */
+export const MISSING_DATE_LABEL = "Date inconnue";
+
+/**
+ * Returns a formatted date string or the appropriate missing-data fallback.
+ * Returns `null` when the line should be hidden entirely.
+ */
+export function resolveDateDisplay(
+    date: Date | string | null | undefined,
+    policy: MissingDatePolicy = "label",
+): string | null {
+    if (!date) {
+        return policy === "label" ? MISSING_DATE_LABEL : null;
+    }
+
+    const parsed = typeof date === "string" ? new Date(date) : date;
+
+    if (isNaN(parsed.getTime())) {
+        return policy === "label" ? MISSING_DATE_LABEL : null;
+    }
+
+    return new Intl.DateTimeFormat("fr-FR", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+    }).format(parsed);
+}


### PR DESCRIPTION
## P1-05 — Trust surface global (provenance, dates, statut) cohérent partout

### Résumé
Surface de confiance unifiée avec :
- **`src/lib/trust.ts`** — SSOT « missing data » : `MissingDatePolicy`, `resolveDateDisplay()`, constante `MISSING_DATE_LABEL = "Date inconnue"`. Jamais "Non renseigné".
- **`ProvenancePanel.tsx`** — composant unifié d'affichage provenance : heading dynamique (h2/h3), dl/dt/dd pour dates, source link ou label, icône statut (ShieldCheck/ShieldAlert/ShieldQuestion).
- **5 stories** couvrant tous les cas : fresh, stale, dates inconnues (policy=label et policy=hide), pas de sourceUrl.

### Règle missing data (SSOT)
| `policy.missingDate` | Date absente | Résultat |
|---|---|---|
| `"label"` (défaut) | `null` / invalide | Affiche "Date inconnue" |
| `"hide"` | `null` / invalide | Masque la ligne |
| — | **Jamais** | ~~Non renseigné~~ **interdit** |

### Vérification "Non renseigné"
```bash
grep -r "Non renseigné" src/lib/trust.ts src/components/organisms/ProvenancePanel.tsx
# → Seul résultat : commentaire JSDoc dans trust.ts (règle), pas de texte UI
```

### Fichiers
| Fichier | Action |
|---------|--------|
| `src/lib/trust.ts` | **NEW** — MissingDatePolicy, resolveDateDisplay, MISSING_DATE_LABEL |
| `src/components/organisms/ProvenancePanel.tsx` | **NEW** — composant trust unifié |
| `src/components/organisms/ProvenancePanel.stories.tsx` | **NEW** — 5 stories |

### A11y
- ✅ Token-only classes (`text-muted-foreground`, `bg-card`, `border-border`)
- ✅ `aria-hidden` icônes, `dl/dt/dd` structure sémantique
- ✅ Focus-visible sur lien source
- ✅ `target="_blank" rel="noopener noreferrer"` sur liens externes
- ✅ Color contrast WCAG AA (text-muted-foreground vs bg-card)
- ✅ Pas de test a11y e2e ajouté (infra Playwright e2e requiert serveur running, hors scope)

### Intégration listing/détail
Choix **le plus minimal** : aucune modification des pages existantes.
- Listing : `AidCard` + `FreshnessTag` déjà cohérents (P1-02/P1-03)
- Détail : `AidDetailLayout` + `FreshnessTag` existants + composant `ProvenancePanel` prêt à brancher

### Preflight
| Commande | Statut |
|----------|--------|
| `npm ci` | ✅ |
| `npm run lint` | ✅ (0 errors) |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ (86 suites, 370 tests) |
| `npm run build` | ✅ |
| `npm run build-storybook` | ✅ |
| `npm run test-storybook` | ✅ (14 suites, 50 tests, 0 a11y violations) |