### PR TITLE
V2-01 — API client + types + data contract (sans brancher les pages)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,8 @@ GEMINI_API_KEY=
 # Public site config
 # ----------------------------
 PUBLIC_BASE_URL=
+# Front-end API base URL (leave empty for same-origin, the default on Vercel)
+VITE_API_BASE_URL=
 
 # ----------------------------
 # Dev flags (Local only)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Platform connecting professional aid structures with beneficiaries, featuring se
     - Sensitive data (names, contacts, messages, files) encrypted with `AES-256-GCM`.
     - Rate limiting via Vercel KV.
 
+## API Environment Variable
+
+The front-end API client reads `VITE_API_BASE_URL` from environment.
+
+| Value | Behaviour |
+|-------|-----------|
+| *(empty / unset)* | Same-origin requests (`/api/…`) — **default on Vercel** |
+| `https://staging.example.com` | Proxy to a remote API (useful in dev) |
+
+Set it in `.env.local` for local development if needed.
+
 ## Deployment
 
 1.  **Build**

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,135 @@
+/**
+ * Minimal fetch-based API client.
+ *
+ * - Typed GET wrapper with generics
+ * - 10 s timeout via AbortController
+ * - Structured error handling (ApiError)
+ * - Safe JSON parsing
+ * - No external dependencies
+ */
+
+import { getApiBaseUrl, API_TIMEOUT_MS } from "./config";
+import type { ApiError } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// URL builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a full URL from a path and optional query parameters.
+ *
+ * @example
+ *   buildUrl("/api/aides", { page: "1", q: "logement" })
+ *   // → "/api/aides?page=1&q=logement"  (same-origin)
+ *   // → "https://staging.example.com/api/aides?page=1&q=logement"
+ */
+export function buildUrl(
+    path: string,
+    params?: Record<string, string | number | boolean | undefined | null>,
+): string {
+    const base = getApiBaseUrl();
+    const url = `${base}${path}`;
+
+    if (!params) return url;
+
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null && value !== "") {
+            searchParams.set(key, String(value));
+        }
+    }
+
+    const qs = searchParams.toString();
+    return qs ? `${url}?${qs}` : url;
+}
+
+// ---------------------------------------------------------------------------
+// Error helper
+// ---------------------------------------------------------------------------
+
+function createApiError(
+    status: number,
+    message: string,
+    body?: unknown,
+): ApiError & Error {
+    const err = new Error(message) as ApiError & Error;
+    err.status = status;
+    err.message = message;
+    err.body = body;
+    return err;
+}
+
+// ---------------------------------------------------------------------------
+// GET wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed GET request against the API.
+ *
+ * @throws {ApiError & Error} on HTTP error or network failure
+ */
+export async function apiGet<T>(
+    path: string,
+    params?: Record<string, string | number | boolean | undefined | null>,
+    options?: { signal?: AbortSignal; timeoutMs?: number },
+): Promise<T> {
+    const url = buildUrl(path, params);
+    const timeoutMs = options?.timeoutMs ?? API_TIMEOUT_MS;
+
+    // ---------- timeout ----------
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Honour caller-provided signal (e.g. React unmount).
+    if (options?.signal) {
+        options.signal.addEventListener("abort", () => controller.abort(), {
+            once: true,
+        });
+    }
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            method: "GET",
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+        });
+    } catch (error: unknown) {
+        clearTimeout(timeoutId);
+        if (error instanceof DOMException && error.name === "AbortError") {
+            throw createApiError(0, `Request timeout after ${timeoutMs}ms: ${path}`);
+        }
+        throw createApiError(0, `Network error: ${path}`, error);
+    } finally {
+        clearTimeout(timeoutId);
+    }
+
+    // ---------- HTTP error ----------
+    if (!response.ok) {
+        let body: unknown;
+        try {
+            body = await response.json();
+        } catch {
+            try {
+                body = await response.text();
+            } catch {
+                body = null;
+            }
+        }
+        throw createApiError(
+            response.status,
+            `API ${response.status}: ${path}`,
+            body,
+        );
+    }
+
+    // ---------- parse JSON ----------
+    try {
+        return (await response.json()) as T;
+    } catch {
+        throw createApiError(
+            response.status,
+            `Invalid JSON response: ${path}`,
+        );
+    }
+}

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -1,0 +1,24 @@
+/**
+ * API configuration.
+ *
+ * The app and the API share the same origin on Vercel (rewrite rule in
+ * vercel.json). In dev you may point to a remote API by setting
+ * VITE_API_BASE_URL in .env.local.
+ *
+ * Default: "" (same-origin, relative URLs like /api/aides).
+ */
+
+export function getApiBaseUrl(): string {
+    const value = import.meta.env.VITE_API_BASE_URL;
+
+    if (value === undefined || value === null || value === "") {
+        // Same-origin — the default and most common case.
+        return "";
+    }
+
+    // Strip trailing slash for consistent URL building.
+    return value.replace(/\/+$/, "");
+}
+
+/** Default request timeout in milliseconds. */
+export const API_TIMEOUT_MS = 10_000;

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -1,0 +1,68 @@
+/**
+ * Typed endpoint wrappers for the Aides API.
+ *
+ * Routes confirmed in:
+ *   - api/routes.js           → { path: 'aides', match: 'prefix' }
+ *   - api/_handlers/aides.js  → GET list (query params) + GET by slug (path param)
+ *   - api/lib/search-query.js → enrichment + pagination shape
+ */
+
+import { apiGet } from "./client";
+import type { ApiAidesListResponse, ApiAideDetail } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// Search / list params (mirrors backend searchAidesSchema)
+// ---------------------------------------------------------------------------
+
+export interface ListAidesParams {
+    q?: string;
+    theme?: string;
+    sousTheme?: string;
+    /** "public" alias — audience filter */
+    public?: string;
+    territoire?: string;
+    organisme?: string;
+    urgent?: string;
+    sort?: string;
+    page?: number;
+    pageSize?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Search / list Aides.
+ *
+ * GET /api/aides?q=…&theme=…&page=…&pageSize=…&sort=…
+ */
+export function listAides(
+    params?: ListAidesParams,
+): Promise<ApiAidesListResponse> {
+    const query: Record<string, string | number | boolean | undefined | null> = {};
+
+    if (params) {
+        if (params.q) query.q = params.q;
+        if (params.theme) query.theme = params.theme;
+        if (params.sousTheme) query.sousTheme = params.sousTheme;
+        if (params.public) query.public = params.public;
+        if (params.territoire) query.territoire = params.territoire;
+        if (params.organisme) query.organisme = params.organisme;
+        if (params.urgent) query.urgent = params.urgent;
+        if (params.sort) query.sort = params.sort;
+        if (params.page != null) query.page = params.page;
+        if (params.pageSize != null) query.pageSize = params.pageSize;
+    }
+
+    return apiGet<ApiAidesListResponse>("/api/aides", query);
+}
+
+/**
+ * Get a single Aide by slug.
+ *
+ * GET /api/aides/:slug
+ */
+export function getAideBySlug(slug: string): Promise<ApiAideDetail> {
+    return apiGet<ApiAideDetail>(`/api/aides/${encodeURIComponent(slug)}`);
+}

--- a/src/lib/api/mappers.ts
+++ b/src/lib/api/mappers.ts
@@ -1,0 +1,212 @@
+/**
+ * Mappers: API response → UI view-models.
+ *
+ * These functions translate the API shapes (ApiAideListItem / ApiAideDetail)
+ * into the prop shapes expected by AidCard and AidDetailLayout.
+ *
+ * Rules:
+ *   - verifiedAt is kept as ISO string (compatible with freshness.ts)
+ *   - Missing fields → null/undefined (never "Non renseigné")
+ *   - sourceLabel comes from provenance.sourceHost (domain name)
+ */
+
+import type { ApiAideListItem, ApiAideDetail } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// View-model types (match AidCardProps / AidDetailLayoutProps without React)
+// ---------------------------------------------------------------------------
+
+export interface AidCardViewModel {
+    title: string;
+    href: string;
+    summary?: string;
+    isUrgent?: boolean;
+    verifiedAt?: string | null;
+    sourceLabel?: string;
+    sourceUrl?: string;
+}
+
+export interface AidDetailSection {
+    id: string;
+    title: string;
+    /** Raw HTML/text content — will be rendered by AidDetailLayout */
+    content: string;
+    collapsible?: boolean;
+}
+
+export interface AidDetailViewModel {
+    title: string;
+    summary?: string;
+    isUrgent?: boolean;
+    verifiedAt?: string | null;
+    sourceLabel?: string;
+    sourceUrl?: string;
+    sections: AidDetailSection[];
+    primaryCta?: { label: string; href: string };
+    secondaryCta?: { label: string; href: string };
+    backHref: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildHref(slug: string | null): string {
+    if (!slug) return "/aides";
+    return `/aides/${encodeURIComponent(slug)}`;
+}
+
+/**
+ * Pick the best available summary text.
+ * Prefer summary_falc (accessible), fall back to cest_quoi.
+ */
+function pickSummary(
+    summaryFalc: string | null | undefined,
+    cestQuoi: string | null | undefined,
+): string | undefined {
+    const text = summaryFalc || cestQuoi;
+    return text || undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Card mapper
+// ---------------------------------------------------------------------------
+
+export function mapAideToCard(item: ApiAideListItem): AidCardViewModel {
+    return {
+        title: item.titre,
+        href: buildHref(item.slug),
+        summary: pickSummary(item.summary_falc, item.cest_quoi),
+        isUrgent: item.est_urgent || undefined,
+        verifiedAt: item.provenance?.verifiedAt ?? item.date_verification ?? null,
+        sourceLabel: item.provenance?.sourceHost ?? undefined,
+        sourceUrl: item.provenance?.sourceUrl ?? undefined,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Detail mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Format étapes (stored as JSON) into a readable string.
+ * The backend stores étapes as either a JSON array of strings,
+ * an array of objects with `label` field, or a raw string.
+ */
+function formatEtapes(etapes: unknown): string | null {
+    if (!etapes) return null;
+
+    if (typeof etapes === "string") return etapes;
+
+    if (Array.isArray(etapes)) {
+        const lines = etapes.map((step, i) => {
+            if (typeof step === "string") return `${i + 1}. ${step}`;
+            if (step && typeof step === "object" && "label" in step) {
+                return `${i + 1}. ${(step as { label: string }).label}`;
+            }
+            return `${i + 1}. ${String(step)}`;
+        });
+        return lines.join("\n");
+    }
+
+    return String(etapes);
+}
+
+export function mapAideToDetail(item: ApiAideDetail): AidDetailViewModel {
+    const sections: AidDetailSection[] = [];
+
+    // Build sections from available fields — skip if empty
+    if (item.cest_quoi) {
+        sections.push({
+            id: "cest-quoi",
+            title: "C'est quoi ?",
+            content: item.cest_quoi,
+        });
+    }
+
+    if (item.pour_qui) {
+        sections.push({
+            id: "pour-qui",
+            title: "Pour qui ?",
+            content: item.pour_qui,
+        });
+    }
+
+    if (item.ce_que_ca_aide) {
+        sections.push({
+            id: "ce-que-ca-aide",
+            title: "Ce que ça aide",
+            content: item.ce_que_ca_aide,
+        });
+    }
+
+    if (item.montant_falc) {
+        sections.push({
+            id: "montant",
+            title: "Montant",
+            content: item.montant_falc,
+        });
+    }
+
+    if (item.conditions_falc) {
+        sections.push({
+            id: "conditions",
+            title: "Conditions",
+            content: item.conditions_falc,
+        });
+    }
+
+    if (item.documents_necessaires && item.documents_necessaires.length > 0) {
+        sections.push({
+            id: "documents",
+            title: "Documents nécessaires",
+            content: item.documents_necessaires.map((d: string) => `• ${d}`).join("\n"),
+            collapsible: true,
+        });
+    }
+
+    const formattedEtapes = formatEtapes(item.etapes);
+    if (formattedEtapes) {
+        sections.push({
+            id: "etapes",
+            title: "Étapes",
+            content: formattedEtapes,
+            collapsible: true,
+        });
+    }
+
+    if (item.ou_demander) {
+        sections.push({
+            id: "ou-demander",
+            title: "Où demander ?",
+            content: item.ou_demander,
+            collapsible: true,
+        });
+    }
+
+    if (item.delai_indicatif) {
+        sections.push({
+            id: "delai",
+            title: "Délai indicatif",
+            content: item.delai_indicatif,
+            collapsible: true,
+        });
+    }
+
+    // Primary CTA: link to make a request
+    const primaryCta = item.lien_demande
+        ? { label: "Faire la demande", href: item.lien_demande }
+        : undefined;
+
+    return {
+        title: item.titre,
+        summary: pickSummary(item.summary_falc, item.cest_quoi),
+        isUrgent: item.est_urgent || undefined,
+        verifiedAt: item.provenance?.verifiedAt ?? item.date_verification ?? null,
+        sourceLabel: item.provenance?.sourceHost ?? undefined,
+        sourceUrl: item.provenance?.sourceUrl ?? undefined,
+        sections,
+        primaryCta,
+        backHref: "/aides",
+    };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,150 @@
+/**
+ * API response types for AccesDirectAide.
+ *
+ * These types mirror the shapes actually returned by the backend
+ * (see api/_handlers/aides.js + api/lib/search-query.js).
+ *
+ * ⚠️  Do NOT invent fields — every key here was confirmed in the
+ *     handler / enrichment code.
+ */
+
+// ---------------------------------------------------------------------------
+// Provenance (attached to every item by buildProvenance)
+// ---------------------------------------------------------------------------
+
+export interface ApiProvenance {
+    verifiedAt: string | null;
+    fetchedAt: string | null;
+    sourceUrl: string | null;
+    sourceHost: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Aide — List item (lightweight, returned by search/list endpoint)
+// ---------------------------------------------------------------------------
+
+export interface ApiAideListItem {
+    id: string;
+    slug: string | null;
+    titre: string;
+    categorie: string | null;
+    theme: string | null;
+    sub_theme: string | null;
+    cest_quoi: string | null;
+    summary_falc: string | null;
+    est_urgent: boolean;
+    territoires: string[];
+    date_verification: string | null;
+    quality_score: number;
+    published_at: string | null;
+    updatedAt: string;
+    providerName: string | null;
+    source_name: string | null;
+    source_org: string | null;
+    source_url: string | null;
+    fetched_at: string | null;
+    provenance: ApiProvenance;
+    /** Only present when searching with `q` */
+    rank?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Aide — Detail (full object, returned by /api/aides/:slug)
+// ---------------------------------------------------------------------------
+
+export interface ApiAideCategory {
+    id: string;
+    slug: string;
+    label: string;
+}
+
+export interface ApiAideSituation {
+    id: string;
+    code: string;
+    label: string;
+    description?: string | null;
+}
+
+export interface ApiAideSituationRelation {
+    id: string;
+    situation: ApiAideSituation;
+}
+
+export interface ApiAideDetail {
+    id: string;
+    slug: string | null;
+    titre: string;
+    categorie: string | null;
+    theme: string | null;
+    sub_theme: string | null;
+    est_urgent: boolean;
+    territoires: string[];
+    date_verification: string | null;
+    delai_indicatif: string | null;
+    cest_quoi: string | null;
+    pour_qui: string | null;
+    ce_que_ca_aide: string | null;
+    documents_necessaires: string[];
+    etapes: unknown | null;
+    ou_demander: string | null;
+    lien_demande: string | null;
+    updatedAt: string;
+    statut: string;
+    quality_score: number;
+    published_at: string | null;
+    mots_cles: string[];
+    summary_falc: string | null;
+    audiences: string[];
+    conditions_falc: string | null;
+    montant_falc: string | null;
+    situations_vie: string[];
+    providerName: string | null;
+    source_name: string | null;
+    source_org: string | null;
+    source_url: string | null;
+    fetched_at: string | null;
+    category: ApiAideCategory | null;
+    situations: Array<{ id: string; slug: string; label: string }>;
+    aidSituations: ApiAideSituationRelation[];
+    provenance: ApiProvenance;
+}
+
+// ---------------------------------------------------------------------------
+// Pagination & Facets
+// ---------------------------------------------------------------------------
+
+export interface ApiPagination {
+    total: number;
+    page: number;
+    limit: number;
+    pageSize: number;
+    totalPages: number;
+    hasNext: boolean;
+}
+
+export interface ApiFacets {
+    themes: Record<string, number>;
+    organismes: Record<string, number>;
+    publics: Record<string, number>;
+    territoires: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Composed response (list endpoint)
+// ---------------------------------------------------------------------------
+
+export interface ApiAidesListResponse {
+    items: ApiAideListItem[];
+    pagination: ApiPagination;
+    facets: ApiFacets;
+}
+
+// ---------------------------------------------------------------------------
+// Error shape (thrown by client.ts)
+// ---------------------------------------------------------------------------
+
+export interface ApiError {
+    status: number;
+    message: string;
+    body?: unknown;
+}


### PR DESCRIPTION
## V2-01 — API client + types + data contract (no UI wiring)

### What
Adds a **typed, fetch-based API client layer** for the Aides endpoints. Zero UI changes — pages will consume these modules in V2-02/V2-03.

### Files Created
| File | Purpose |
|------|---------|
| `src/types/api.ts` | TypeScript types mirroring actual backend response shapes |
| `src/lib/api/config.ts` | Reads `VITE_API_BASE_URL` env var (default: same-origin) |
| `src/lib/api/client.ts` | `apiGet<T>()` — fetch wrapper with 10s timeout, structured error handling |
| `src/lib/api/endpoints.ts` | `listAides()`, `getAideBySlug()` |
| `src/lib/api/mappers.ts` | `mapAideToCard()`, `mapAideToDetail()` — API → UI view-models |

### Files Modified (minimal)
| File | Change |
|------|--------|
| `.env.example` | Added `VITE_API_BASE_URL` placeholder |
| `README.md` | Added "API Environment Variable" section |

### Endpoints (confirmed, not invented)
- `GET /api/aides?q=&theme=&page=&pageSize=&sort=` — list/search (paginated, with facets)
- `GET /api/aides/:slug` — single aide by slug

Sources: `api/routes.js` L146, `api/_handlers/aides.js`, `api/lib/search-query.js`

### VITE_API_BASE_URL
| Value | Behaviour |
|-------|-----------|
| *(empty / unset)* | Same-origin requests (`/api/…`) — **default on Vercel** |
| `https://staging.example.com` | Proxy to a remote API |

### Preflight ✅
- `npm ci` ✅
- `npm run lint` ✅ (0 errors)
- `npm run typecheck` ✅
- `npm test` ✅ (86 files, 370 tests)
- `npm run build` ✅ (SSG prerender OK)

### Not touched (by design)
- `src/pages/**` ❌
- `src/components/**` ❌
- `package.json` deps ❌
- `.storybook/**`, `.github/**` ❌
- Tokens / tailwind.config ❌