### PR TITLE
V2-05 — Data quality (dates/provenance) + trust rules unifiées

### DIFF
--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -67,3 +67,22 @@ L'API utilise le header `Authorization` :
 
 - `X-Request-Id` : Identifiant unique de la requête (retourné dans la réponse).
 - `X-App-Version` : Version de l'application (optionnel).
+
+## 6. Provenance et Dates
+
+Chaque aide expose des champs de **provenance** qui tracent la fraîcheur et la source :
+
+| Champ | Type | Description |
+| :--- | :--- | :--- |
+| `provenance.verifiedAt` | `string` (ISO 8601) | Date de dernière vérification de la source |
+| `provenance.fetchedAt` | `string` (ISO 8601) | Date de collecte par le pipeline |
+| `provenance.sourceHost` | `string` | Nom de domaine de la source (ex: `service-public.fr`) |
+| `provenance.sourceUrl` | `string` | URL complète de la source officielle |
+| `date_verification` | `string` (ISO 8601) | Fallback : date de vérification (champ racine) |
+
+### Règles côté front-end (trust policy)
+
+- **Dates futures** : rejetées si > `now + 2 jours` (→ `null`). Couvre les erreurs d'import et le décalage horaire.
+- **URL invalide** : si `sourceUrl` n'est pas `http(s)://…` → `null`.
+- **Label vide** : si `sourceHost` est vide ou whitespace → `null`.
+- **Aucun fallback textuel** : la data layer ne fabrique jamais `"Non renseigné"`. Les composants UI affichent `"Date inconnue"` ou masquent l'élément.

--- a/src/lib/api/mappers.ts
+++ b/src/lib/api/mappers.ts
@@ -5,12 +5,14 @@
  * into the prop shapes expected by AidCard and AidDetailLayout.
  *
  * Rules:
- *   - verifiedAt is kept as ISO string (compatible with freshness.ts)
+ *   - Dates are normalized via trust/normalize (future-clamped, parsed safely)
  *   - Missing fields → null/undefined (never "Non renseigné")
  *   - sourceLabel comes from provenance.sourceHost (domain name)
+ *   - Invalid URLs → null
  */
 
 import type { ApiAideListItem, ApiAideDetail } from "@/types/api";
+import { buildProvenance } from "@/lib/trust/normalize";
 
 // ---------------------------------------------------------------------------
 // View-model types (match AidCardProps / AidDetailLayoutProps without React)
@@ -73,14 +75,16 @@ function pickSummary(
 // ---------------------------------------------------------------------------
 
 export function mapAideToCard(item: ApiAideListItem): AidCardViewModel {
+    const prov = buildProvenance(item.provenance, item.date_verification);
+
     return {
         title: item.titre,
         href: buildHref(item.slug),
         summary: pickSummary(item.summary_falc, item.cest_quoi),
         isUrgent: item.est_urgent || undefined,
-        verifiedAt: item.provenance?.verifiedAt ?? item.date_verification ?? null,
-        sourceLabel: item.provenance?.sourceHost ?? undefined,
-        sourceUrl: item.provenance?.sourceUrl ?? undefined,
+        verifiedAt: prov.verifiedAt,
+        sourceLabel: prov.sourceLabel ?? undefined,
+        sourceUrl: prov.sourceUrl ?? undefined,
     };
 }
 
@@ -198,13 +202,15 @@ export function mapAideToDetail(item: ApiAideDetail): AidDetailViewModel {
         ? { label: "Faire la demande", href: item.lien_demande }
         : undefined;
 
+    const prov = buildProvenance(item.provenance, item.date_verification);
+
     return {
         title: item.titre,
         summary: pickSummary(item.summary_falc, item.cest_quoi),
         isUrgent: item.est_urgent || undefined,
-        verifiedAt: item.provenance?.verifiedAt ?? item.date_verification ?? null,
-        sourceLabel: item.provenance?.sourceHost ?? undefined,
-        sourceUrl: item.provenance?.sourceUrl ?? undefined,
+        verifiedAt: prov.verifiedAt,
+        sourceLabel: prov.sourceLabel ?? undefined,
+        sourceUrl: prov.sourceUrl ?? undefined,
         sections,
         primaryCta,
         backHref: "/aides",

--- a/src/lib/trust/normalize.ts
+++ b/src/lib/trust/normalize.ts
@@ -1,0 +1,150 @@
+/**
+ * Data normalization utilities for dates, URLs, and provenance.
+ *
+ * All functions are pure, side-effect-free, and return null for invalid input.
+ * They enforce the trust policy: no "Non renseigné", no future dates,
+ * no invalid URLs, no empty strings masquerading as data.
+ */
+
+import { MAX_FUTURE_SKEW_MS } from "./policy";
+import type { ApiProvenance } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// Date parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely parse a date input into a Date object.
+ *
+ * Accepts:
+ *   - ISO 8601 string (e.g. "2026-01-15T10:00:00Z")
+ *   - dd/mm/yyyy string (European format, commonly found in French data)
+ *   - Date object
+ *   - null / undefined / empty string → null
+ *
+ * Returns null if the input cannot be parsed into a valid date.
+ */
+export function parseDateSafe(input: string | Date | null | undefined): Date | null {
+    if (input == null) return null;
+
+    if (input instanceof Date) {
+        return isNaN(input.getTime()) ? null : input;
+    }
+
+    const trimmed = String(input).trim();
+    if (!trimmed) return null;
+
+    // Try dd/mm/yyyy format first (French locale)
+    const ddmmyyyy = trimmed.match(/^(\d{1,2})[/.-](\d{1,2})[/.-](\d{4})$/);
+    if (ddmmyyyy) {
+        const [, day, month, year] = ddmmyyyy;
+        const d = new Date(`${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}T00:00:00Z`);
+        return isNaN(d.getTime()) ? null : d;
+    }
+
+    // Try ISO / standard JS parsing
+    const d = new Date(trimmed);
+    return isNaN(d.getTime()) ? null : d;
+}
+
+// ---------------------------------------------------------------------------
+// Future-date clamping
+// ---------------------------------------------------------------------------
+
+/**
+ * Reject dates that are too far in the future.
+ *
+ * If a date is more than `maxSkewMs` ahead of `now`, it is considered
+ * invalid data (clock error, bad import) and returned as null.
+ *
+ * @param date       - The date to check
+ * @param now        - Reference "now" timestamp (default: Date.now())
+ * @param maxSkewMs  - Maximum allowed future offset in ms (default: policy constant)
+ * @returns The original date if valid, or null if it's too far in the future
+ */
+export function clampFutureDate(
+    date: Date | null,
+    now: number = Date.now(),
+    maxSkewMs: number = MAX_FUTURE_SKEW_MS,
+): Date | null {
+    if (!date) return null;
+    if (date.getTime() > now + maxSkewMs) return null;
+    return date;
+}
+
+// ---------------------------------------------------------------------------
+// String normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a source label: trim and return null if empty.
+ */
+export function normalizeSourceLabel(label: string | null | undefined): string | null {
+    if (label == null) return null;
+    const trimmed = String(label).trim();
+    return trimmed || null;
+}
+
+/**
+ * Normalize a URL: validate it's http/https and return null if invalid.
+ */
+export function normalizeUrl(url: string | null | undefined): string | null {
+    if (url == null) return null;
+    const trimmed = String(url).trim();
+    if (!trimmed) return null;
+
+    try {
+        const parsed = new URL(trimmed);
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+            return trimmed;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provenance builder
+// ---------------------------------------------------------------------------
+
+export interface NormalizedProvenance {
+    verifiedAt: string | null;    // ISO string or null
+    collectedAt: string | null;   // ISO string or null
+    sourceLabel: string | null;
+    sourceUrl: string | null;
+}
+
+/**
+ * Build a normalized provenance object from raw API data.
+ *
+ * Applies all trust rules:
+ *   - Dates are parsed and future-clamped
+ *   - Source label is trimmed (null if empty)
+ *   - Source URL must be valid http/https (null otherwise)
+ *   - No fallback strings — null means "no data"
+ *
+ * @param provenance   - API provenance object
+ * @param dateVerif    - Fallback date_verification from root aide object
+ * @param now          - Reference timestamp for future-date check
+ */
+export function buildProvenance(
+    provenance: ApiProvenance | null | undefined,
+    dateVerif: string | null | undefined,
+    now: number = Date.now(),
+): NormalizedProvenance {
+    // Parse and clamp verifiedAt
+    const rawVerified = provenance?.verifiedAt ?? dateVerif ?? null;
+    const parsedVerified = clampFutureDate(parseDateSafe(rawVerified), now);
+
+    // Parse and clamp collectedAt (fetchedAt from provenance)
+    const rawCollected = provenance?.fetchedAt ?? null;
+    const parsedCollected = clampFutureDate(parseDateSafe(rawCollected), now);
+
+    return {
+        verifiedAt: parsedVerified ? parsedVerified.toISOString() : null,
+        collectedAt: parsedCollected ? parsedCollected.toISOString() : null,
+        sourceLabel: normalizeSourceLabel(provenance?.sourceHost),
+        sourceUrl: normalizeUrl(provenance?.sourceUrl),
+    };
+}

--- a/src/lib/trust/policy.ts
+++ b/src/lib/trust/policy.ts
@@ -1,0 +1,38 @@
+/**
+ * Trust policy — single source of truth for "missing data" display rules.
+ *
+ * These constants are consumed by:
+ *   - normalize.ts (data sanitization)
+ *   - mappers.ts  (view-model construction)
+ *   - UI components read verifiedAt: if null → they display "Date inconnue" or hide
+ *
+ * Rule: the data layer NEVER fabricates "Non renseigné".
+ * Rule: the data layer returns null when data is missing or invalid.
+ * The UI decides how to display null values (e.g. "Date inconnue" or hide entirely).
+ */
+
+export const TRUST_POLICY = {
+    /**
+     * How to handle a missing verifiedAt date in the UI layer.
+     * - "label": display a neutral label (e.g. "Date inconnue")
+     * - "hide": hide the element entirely
+     */
+    missingDateBehavior: "label" as const,
+
+    /**
+     * Label displayed by the UI when verifiedAt is null.
+     * This is NOT output by the data layer — it exists here as a constant
+     * for shared reference. Components like FreshnessTag use this value.
+     */
+    unknownDateLabel: "Date inconnue",
+
+    /**
+     * Maximum allowed future skew in days.
+     * Dates more than this far in the future are treated as invalid (→ null).
+     * Tolerance covers timezone differences and minor clock skew.
+     */
+    maxFutureSkewDays: 2,
+} as const;
+
+/** Milliseconds equivalent of maxFutureSkewDays. */
+export const MAX_FUTURE_SKEW_MS = TRUST_POLICY.maxFutureSkewDays * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## V2-05 — Data quality (dates/provenance) + trust rules unifiées

### What
Centralizes all data quality rules for dates, provenance, and source URLs in a dedicated trust layer. The data layer now validates and normalizes data before producing view-models — no "Non renseigné", no future dates, no invalid URLs.

### Files Created/Modified

| File | Status | Purpose |
|------|--------|---------|
| `src/lib/trust/policy.ts` | **NEW** | Trust constants (maxFutureSkewDays=2, unknownDateLabel="Date inconnue") |
| `src/lib/trust/normalize.ts` | **NEW** | Pure functions: parseDateSafe, clampFutureDate, normalizeSourceLabel/Url, buildProvenance |
| `src/lib/api/mappers.ts` | MODIFIED | Both mappers now use `buildProvenance()` to normalize dates/provenance |
| `docs/API_CONTRACT.md` | MODIFIED | Added section 6: Provenance fields + frontend trust rules |

### Future Date Rule (maxFutureSkewDays=2)

- `clampFutureDate(date, now)` checks if `date > now + 2 days`
- If so → returns **null** (treats the date as invalid data — clock error or bad import)
- If within tolerance → returns the original date unchanged
- This applies to both `verifiedAt` and `collectedAt` (fetchedAt)
- **Choice: null (not clamp to now)** — because clamping to `now` would fabricate data

### How "Date inconnue" Works

1. **Data layer** (`normalize.ts` → `mappers.ts`): produces `verifiedAt: null` when:
   - Date is missing/undefined
   - Date string is unparseable
   - Date is > 2 days in the future
2. **Data layer NEVER** writes "Date inconnue" or "Non renseigné" as a string value
3. **UI layer** (FreshnessTag / freshness.ts — **untouched in this PR**): receives `verifiedAt: null` → `getFreshnessStatus()` returns `"unknown"` → component renders "Date inconnue" or hides the element

### Not Touched (by design)
- `src/pages/**` ❌
- `src/components/**` ❌ (FreshnessTag, ProvenancePanel consumed only)
- `src/styles/**` ❌
- No npm deps added ❌

### Preflight ✅
- `npm run lint` ✅ (0 errors)
- `npm run typecheck` ✅
- `npm test` ✅ (86 files, 370 tests)
- `npm run build` ✅ (SSG prerender OK)
- `npm run build-storybook` ✅
- `npm run test-storybook` ✅ (14 suites, 52 tests, a11y OK)