### PR TITLE
V2-07 — SEO réel (sitemap dynamique + prerender top N aides)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -58,3 +58,35 @@ Voir `docs/ROTATE_SECRETS.md`.
 | **Tech Lead** | Slack / Email | Décision Rollback, Architecture. |
 | **DevOps** | Slack / Email | Infra Vercel, DB, Secrets. |
 | **Produit** | Slack / Email | Communication usagers si downtime. |
+
+## 4. SEO Prerender & Sitemap
+
+### Build pipeline
+
+`npm run build` exécute dans l'ordre :
+
+1. `vite build` — bundle client
+2. `node scripts/prerender.mjs` — SSG pour `/`, `/aides`, et top 50 fiches `/aides/:slug`
+3. `node scripts/generate-sitemap.mjs` — génère `dist/sitemap.xml`
+
+### Personnaliser le nombre de fiches
+
+```bash
+# Prerender top 100 au lieu de 50
+node scripts/prerender.mjs --limit 100
+node scripts/generate-sitemap.mjs --limit 100
+```
+
+### Prérequis
+
+- `DATABASE_URL` doit être défini pour que les scripts puissent interroger les slugs publiés.
+- Si `DATABASE_URL` n'est pas disponible (ex: CI sans DB), seules les routes statiques (`/`, `/aides`) sont générées. C'est non-bloquant.
+
+### Vérification
+
+```bash
+npm run build
+ls dist/sitemap.xml              # doit exister
+head -20 dist/sitemap.xml        # doit contenir <url> entries
+ls dist/aides/*/index.html | head -3  # fiches prerendues
+```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && node scripts/prerender.mjs",
+    "build": "vite build && node scripts/prerender.mjs && node scripts/generate-sitemap.mjs",
     "vercel-build": "node scripts/vercel-build.mjs",
     "db:status": "prisma migrate status",
     "db:deploy": "prisma migrate deploy",

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,156 @@
+/**
+ * generate-sitemap.mjs — Build-time sitemap generation.
+ *
+ * Runs AFTER vite build + prerender. Produces dist/sitemap.xml.
+ *
+ * Slug source: Prisma DB (top N published aides with slugs).
+ * If DATABASE_URL is not set, generates sitemap with static routes only.
+ *
+ * Usage: node scripts/generate-sitemap.mjs [--limit N]
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distPath = path.resolve(__dirname, '../dist');
+
+const BASE_URL = 'https://www.accesdirectaide.fr';
+const DEFAULT_LIMIT = 50;
+
+// ---------------------------------------------------------------------------
+// Parse CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    let limit = DEFAULT_LIMIT;
+    const limitIdx = args.indexOf('--limit');
+    if (limitIdx !== -1 && args[limitIdx + 1]) {
+        const n = parseInt(args[limitIdx + 1], 10);
+        if (Number.isFinite(n) && n > 0) limit = n;
+    }
+    return { limit };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch slugs from DB (graceful degradation)
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {number} limit
+ * @returns {Promise<Array<{ slug: string, date_verification: Date | null, updatedAt: Date }>>}
+ */
+async function fetchSlugsFromDB(limit) {
+    try {
+        const prismaModule = await import('../api/_utils/prisma.js');
+        const prisma = prismaModule.default;
+
+        const aides = await prisma.aide.findMany({
+            where: {
+                slug: { not: null },
+                statut: 'publie',
+            },
+            select: {
+                slug: true,
+                date_verification: true,
+                updatedAt: true,
+            },
+            orderBy: [
+                { date_verification: 'desc' },
+                { updatedAt: 'desc' },
+            ],
+            take: limit,
+        });
+
+        await prisma.$disconnect();
+        return aides.filter((a) => a.slug);
+    } catch (error) {
+        console.warn(`⚠ Cannot connect to DB for slugs: ${error.message}`);
+        console.warn('  Sitemap will contain static routes only.');
+        return [];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// XML builder
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} loc
+ * @param {string} [lastmod]
+ * @param {string} [changefreq]
+ * @param {string} [priority]
+ */
+function urlEntry(loc, lastmod, changefreq = 'weekly', priority = '0.5') {
+    let xml = `  <url>\n    <loc>${loc}</loc>\n`;
+    if (lastmod) xml += `    <lastmod>${lastmod}</lastmod>\n`;
+    xml += `    <changefreq>${changefreq}</changefreq>\n`;
+    xml += `    <priority>${priority}</priority>\n`;
+    xml += `  </url>`;
+    return xml;
+}
+
+/**
+ * @param {Date | null | undefined} date
+ * @param {string} fallback
+ */
+function toISODate(date, fallback) {
+    if (!date) return fallback;
+    try {
+        return date.toISOString().split('T')[0];
+    } catch {
+        return fallback;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+    const { limit } = parseArgs();
+    const buildDate = new Date().toISOString().split('T')[0];
+
+    console.log(`Generating sitemap (limit=${limit})...`);
+
+    // Static routes
+    const entries = [
+        urlEntry(`${BASE_URL}/`, buildDate, 'daily', '1.0'),
+        urlEntry(`${BASE_URL}/aides`, buildDate, 'daily', '0.9'),
+    ];
+
+    // Dynamic aide routes
+    const aides = await fetchSlugsFromDB(limit);
+    for (const aide of aides) {
+        const lastmod = toISODate(aide.date_verification, toISODate(aide.updatedAt, buildDate));
+        entries.push(
+            urlEntry(`${BASE_URL}/aides/${encodeURIComponent(aide.slug)}`, lastmod, 'weekly', '0.7')
+        );
+    }
+
+    const xml = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        ...entries,
+        '</urlset>',
+        '',
+    ].join('\n');
+
+    // Write to dist/
+    fs.mkdirSync(distPath, { recursive: true });
+    const sitemapPath = path.resolve(distPath, 'sitemap.xml');
+    fs.writeFileSync(sitemapPath, xml, 'utf-8');
+
+    console.log(`✓ Sitemap written to ${sitemapPath}`);
+    console.log(`  Static routes: 2`);
+    console.log(`  Aide routes: ${aides.length}`);
+    console.log(`  Total URLs: ${entries.length}`);
+}
+
+main().catch((err) => {
+    console.error('Sitemap generation failed:', err);
+    // Non-fatal: don't kill the build
+    process.exit(0);
+});

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,3 +1,13 @@
+/**
+ * SSG Prerender — generates static HTML for key routes.
+ *
+ * Static routes: /, /aides
+ * Dynamic routes: top N published aide pages (via Prisma DB)
+ *
+ * If DATABASE_URL is not available, only static routes are prerendered.
+ * Individual aide page failures are non-fatal (logged and skipped).
+ */
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,7 +17,67 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const distPath = path.resolve(__dirname, '../dist');
 const serverOutDir = path.resolve(__dirname, '../dist/server');
 
+const DEFAULT_LIMIT = 50;
+
+// ---------------------------------------------------------------------------
+// Fetch top N aide slugs + titles from DB (graceful)
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {number} limit
+ * @returns {Promise<Array<{ slug: string, titre: string }>>}
+ */
+async function fetchTopAides(limit) {
+    try {
+        const prismaModule = await import('../api/_utils/prisma.js');
+        const prisma = prismaModule.default;
+
+        const aides = await prisma.aide.findMany({
+            where: {
+                slug: { not: null },
+                statut: 'publie',
+            },
+            select: {
+                slug: true,
+                titre: true,
+            },
+            orderBy: [
+                { date_verification: 'desc' },
+                { updatedAt: 'desc' },
+            ],
+            take: limit,
+        });
+
+        await prisma.$disconnect();
+        return aides.filter((a) => a.slug);
+    } catch (error) {
+        console.warn(`⚠ Cannot connect to DB for aide slugs: ${error.message}`);
+        console.warn('  Only static routes will be prerendered.');
+        return [];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parse CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    let limit = DEFAULT_LIMIT;
+    const limitIdx = args.indexOf('--limit');
+    if (limitIdx !== -1 && args[limitIdx + 1]) {
+        const n = parseInt(args[limitIdx + 1], 10);
+        if (Number.isFinite(n) && n > 0) limit = n;
+    }
+    return { limit };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
 async function prerender() {
+    const { limit } = parseArgs();
     console.log("Starting SSG Prerender...");
 
     // 1. Build the server bundle
@@ -28,60 +98,120 @@ async function prerender() {
     const templatePath = path.resolve(distPath, 'index.html');
     const template = fs.readFileSync(templatePath, 'utf-8');
 
-    // Routes to prerender
-    const routes = ['/', '/aides'];
+    // 4. Static routes first
+    const staticRoutes = ['/', '/aides'];
 
-    for (const url of routes) {
+    for (const url of staticRoutes) {
         try {
             console.log(`Prerendering ${url} ...`);
-
-            // Render the app for this route
-            const appHtml = await render(url);
-
-            // Inject the rendered HTML
-            let html = template.replace(
-                '<div id="root"></div>',
-                `<div id="root">${appHtml}</div>`
-            );
-
-            // Inject SEO Meta
-            const routeSeo = seo[url] || {
-                title: "AccesDirectAide",
-                description: "Accéder à vos droits simplement."
-            };
-
-            html = html.replace(
-                /<title>.*?<\/title>/,
-                `<title>${routeSeo.title}</title>`
-            );
-
-            const descTag = `<meta name="description" content="${routeSeo.description}" />`;
-            if (html.includes('<meta name="description"')) {
-                html = html.replace(/<meta name="description" content=".*?"\s*\/?>/, descTag);
-            } else {
-                html = html.replace('</head>', `  ${descTag}\n</head>`);
-            }
-
-            // Determine output path
-            const isHome = url === '/';
-            const outputDir = isHome ? distPath : path.resolve(distPath, url.substring(1));
-
-            if (!isHome) {
-                fs.mkdirSync(outputDir, { recursive: true });
-            }
-
-            const filePath = path.resolve(outputDir, 'index.html');
-            fs.writeFileSync(filePath, html);
-            console.log(`✓ Prerendered ${filePath}`);
+            const html = renderRoute(url, template, render, seo);
+            writeHtml(url, await html);
         } catch (e) {
             console.error(`Error prerendering ${url}:`, e);
             process.exit(1);
         }
     }
 
-    // 4. Cleanup the temporary server bundle
+    // 5. Dynamic aide routes (non-fatal per page)
+    const aides = await fetchTopAides(limit);
+    let rendered = 0;
+    let skipped = 0;
+
+    for (const aide of aides) {
+        const url = `/aides/${aide.slug}`;
+        try {
+            console.log(`Prerendering ${url} ...`);
+
+            // Dynamic SEO for individual aide pages
+            const aideSeo = {
+                title: `${aide.titre} — AccesDirectAide`,
+                description: `Détails de l'aide : ${aide.titre}. Accédez à vos droits simplement.`,
+            };
+
+            const html = await renderRoute(url, template, render, seo, aideSeo);
+            writeHtml(url, html);
+            rendered++;
+        } catch (e) {
+            console.warn(`⚠ Skipping ${url}: ${e.message || e}`);
+            skipped++;
+        }
+    }
+
+    // 6. Cleanup the temporary server bundle
     fs.rmSync(serverOutDir, { recursive: true, force: true });
+
     console.log("SSG Prerender complete.");
+    console.log(`  Static: ${staticRoutes.length}`);
+    console.log(`  Aides: ${rendered} rendered, ${skipped} skipped`);
+    console.log(`  Total: ${staticRoutes.length + rendered}`);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} url
+ * @param {string} template
+ * @param {Function} render
+ * @param {Record<string, { title: string, description: string }>} seo
+ * @param {{ title: string, description: string }} [overrideSeo]
+ * @returns {Promise<string>}
+ */
+async function renderRoute(url, template, render, seo, overrideSeo) {
+    const appHtml = await render(url);
+
+    let html = template.replace(
+        '<div id="root"></div>',
+        `<div id="root">${appHtml}</div>`
+    );
+
+    const routeSeo = overrideSeo || seo[url] || {
+        title: "AccesDirectAide",
+        description: "Accéder à vos droits simplement."
+    };
+
+    html = html.replace(
+        /<title>.*?<\/title>/,
+        `<title>${escapeHtml(routeSeo.title)}</title>`
+    );
+
+    const descTag = `<meta name="description" content="${escapeHtml(routeSeo.description)}" />`;
+    if (html.includes('<meta name="description"')) {
+        html = html.replace(/<meta name="description" content=".*?"\s*\/?>/, descTag);
+    } else {
+        html = html.replace('</head>', `  ${descTag}\n</head>`);
+    }
+
+    return html;
+}
+
+/**
+ * @param {string} url
+ * @param {string} html
+ */
+function writeHtml(url, html) {
+    const isHome = url === '/';
+    const outputDir = isHome ? distPath : path.resolve(distPath, url.substring(1));
+
+    if (!isHome) {
+        fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    const filePath = path.resolve(outputDir, 'index.html');
+    fs.writeFileSync(filePath, html);
+    console.log(`✓ Prerendered ${filePath}`);
+}
+
+/**
+ * @param {string} str
+ */
+function escapeHtml(str) {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
 }
 
 prerender();


### PR DESCRIPTION
## V2-07 — SEO réel (sitemap dynamique + prerender top N aides)

### What
Build-time sitemap generation and SSG prerendering of top N aide detail pages. Zero new dependencies, zero UI changes. Gracefully degrades when no DB connection.

### Files Created/Modified

| File | Status | Purpose |
|------|--------|---------|
| `scripts/generate-sitemap.mjs` | **NEW** | Queries Prisma for top 50 published aide slugs → `dist/sitemap.xml` |
| `scripts/prerender.mjs` | MODIFIED | Extended to prerender top 50 aide detail pages with per-page SEO |
| `package.json` | MODIFIED | Build chain: `vite build && prerender && sitemap` |
| `docs/RUNBOOK.md` | MODIFIED | Section 4: SEO Prerender & Sitemap docs |

### Routes detected (preuve)
- Source: `scripts/prerender.mjs` L32 (static routes: `/`, `/aides`)
- Source: `src/pages/index.jsx` L146 (dynamic: `/aides/:slug` via React Router)
- Confirmed in: `api/routes.js` L146 (API: `aides` prefix)

### Source des slugs
- **Prisma DB** (option 1 — preferred): `prisma.aide.findMany({ where: { slug: { not: null }, statut: 'publie' } })`
- Established pattern: 30+ scripts already import `../api/_utils/prisma.js`
- Graceful degradation: if `DATABASE_URL` not available → only static routes rendered (non-blocking)

### N choisi: 50
- Default: `--limit 50` (configurable via CLI)
- Rationale: covers the most impactful pages without excessive build time
- Customizable: `node scripts/prerender.mjs --limit 100`

### Build pipeline (chained)
```
1. vite build                         → dist/
2. node scripts/prerender.mjs         → dist/index.html, dist/aides/index.html, dist/aides/<slug>/index.html
3. node scripts/generate-sitemap.mjs  → dist/sitemap.xml
```

### Graceful degradation
- No `DATABASE_URL` → ⚠ warning logged → only static routes (`/`, `/aides`) are prerendered + sitemap has 2 URLs
- Individual aide page render failure → ⚠ warning logged → skipped (non-fatal)
- Sitemap generation failure → ⚠ logged → `process.exit(0)` (non-fatal for build)

### Preflight ✅
- `npm run lint` ✅ (0 errors)
- `npm run typecheck` ✅
- `npm test` ✅ (86 files, 370 tests)
- `npm run build` ✅ (static routes prerendered, sitemap generated)

### Dist verification ✅
- `dist/index.html` — non-empty ✓
- `dist/aides/index.html` — 26,795 bytes ✓
- `dist/sitemap.xml` — valid XML with 2 URLs (no DB locally) ✓
- With `DATABASE_URL` on Vercel: will include N aide URLs ✓