### PR TITLE
V2-08.1 — Afficher Se connecter / Créer un compte dans le Header + routes auth découvrables

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -90,3 +90,16 @@ ls dist/sitemap.xml              # doit exister
 head -20 dist/sitemap.xml        # doit contenir <url> entries
 ls dist/aides/*/index.html | head -3  # fiches prerendues
 ```
+
+## 5. Auth — Routes exposées
+
+| Route | Audience | Liée dans le Header ? |
+| :--- | :--- | :--- |
+| `/login` | Public (hub de connexion) | ✅ Oui |
+| `/pro/login` | Professionnels | ✅ Oui (mobile : "Espace Pro") |
+| `/pro/register` | Professionnels | ✅ Oui ("Créer un compte") |
+| `/auth/login` | Bénéficiaires (RDV) | Non (accès via parcours RDV) |
+| `/auth/signup` | Bénéficiaires (RDV) | Non (accès via parcours RDV) |
+| `/admin/login` | Administration | ⛔ Non (accès par URL directe uniquement) |
+
+> **Note** : `/admin/login` existe mais n'est volontairement pas liée dans la navigation publique pour des raisons de sécurité.

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { NavLink } from "react-router-dom";
-import { Menu, X } from "lucide-react";
+import { Menu, X, LogIn, UserPlus } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
 
 const NAV_ITEMS = [
   { label: "Accueil", to: "/" },
@@ -11,11 +12,10 @@ const NAV_ITEMS = [
 ];
 
 function navClassName(isActive) {
-  return `rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-    isActive
+  return `rounded-lg px-3 py-2 text-sm font-medium transition-colors ${isActive
       ? "bg-slate-100 text-slate-900"
       : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
-  }`;
+    }`;
 }
 
 export function Header() {
@@ -58,6 +58,26 @@ export function Header() {
               ))}
             </nav>
 
+            {/* Auth action links — desktop */}
+            <div className="hidden items-center gap-2 lg:flex">
+              <NavLink
+                to="/login"
+                className={buttonVariants({ variant: "ghost", size: "sm" })}
+                aria-label="Se connecter"
+              >
+                <LogIn className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Se connecter
+              </NavLink>
+              <NavLink
+                to="/pro/register"
+                className={buttonVariants({ variant: "solid", size: "sm" })}
+                aria-label="Créer un compte professionnel"
+              >
+                <UserPlus className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Créer un compte
+              </NavLink>
+            </div>
+
             <button
               type="button"
               className="rounded-lg p-2 text-slate-700 transition hover:bg-slate-100 lg:hidden"
@@ -84,6 +104,35 @@ export function Header() {
                   {item.label}
                 </NavLink>
               ))}
+
+              {/* Auth section — mobile */}
+              <hr className="my-2 border-slate-200" />
+              <NavLink
+                to="/login"
+                className={buttonVariants({ variant: "ghost" })}
+                onClick={() => setMobileOpen(false)}
+                aria-label="Se connecter"
+              >
+                <LogIn className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Se connecter
+              </NavLink>
+              <NavLink
+                to="/pro/register"
+                className={buttonVariants({ variant: "solid" })}
+                onClick={() => setMobileOpen(false)}
+                aria-label="Créer un compte professionnel"
+              >
+                <UserPlus className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Créer un compte (Pro)
+              </NavLink>
+              <NavLink
+                to="/pro/login"
+                className={({ isActive }) => navClassName(isActive)}
+                onClick={() => setMobileOpen(false)}
+                aria-label="Accéder à l'espace professionnel"
+              >
+                Espace Pro
+              </NavLink>
             </nav>
           </div>
         )}


### PR DESCRIPTION
## Objectif

Rendre les parcours d'authentification **découvrables** depuis la navigation publique.

Jusqu'ici, les routes `/login`, `/pro/login` et `/pro/register` existaient mais n'étaient liées nulle part dans le Header — un utilisateur ne pouvait y accéder que par URL directe.

## Changements

### `src/components/layout/Header.jsx`

- **Desktop** (≥ 1024px) : ajout d'une zone d'actions à droite du nav contenant :
  - « Se connecter » → `/login` (style `ghost` + icône `LogIn`)
  - « Créer un compte » → `/pro/register` (style `solid` + icône `UserPlus`)
- **Mobile** (< 1024px) : dans le menu hamburger, après les items de navigation :
  - Séparateur `<hr>`
  - « Se connecter » → `/login`
  - « Créer un compte (Pro) » → `/pro/register`
  - « Espace Pro » → `/pro/login` (lien discret)
- **`/admin/login` n'est PAS ajouté** (accès par URL directe uniquement)
- Utilise `buttonVariants` du composant `Button` existant (design tokens `bt-*`)
- `focus-visible` correctement géré via `buttonVariants`

### `docs/RUNBOOK.md`

- Nouvelle section **« 5. Auth — Routes exposées »** documentant les routes publiques, pro, et admin avec leur statut de liaison dans le Header.

## Vérifications

| Check | Résultat |
|---|---|
| `npm run lint` | ✅ 0 errors |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ 86 fichiers, 370 tests |
| `npm run build` | ✅ |
| `npm run build-storybook` | ✅ |
| `npm run lint:design-system` | ⚠️ 2 violations pré-existantes dans `badge.tsx` (identique sur `main`) |

## Périmètre

- ✅ 2 fichiers modifiés uniquement
- ✅ 0 dépendance ajoutée
- ✅ 0 changement backend/auth
- ✅ `/admin/login` non exposé