### PR TITLE
HOTFIX — Auth links visibles en prod (Layout header)

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -15,9 +15,11 @@ import {
   ListChecks,
   Info,
   Calendar,
-  ChevronDown
+  ChevronDown,
+  LogIn,
+  UserPlus
 } from 'lucide-react';
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import AccessibilityToolbar from '@/components/ui/AccessibilityToolbar';
 import ChatAssistant from '@/components/chat/ChatAssistant';
 import { adminClient as client } from '@/api/client';
@@ -277,6 +279,26 @@ export default function Layout({ children, currentPageName }) {
               ))}
             </nav>
 
+            {/* Auth links — desktop */}
+            <div className="hidden items-center gap-2 lg:flex">
+              <Link
+                to="/login"
+                className={buttonVariants({ variant: 'ghost', size: 'sm' })}
+                aria-label="Se connecter"
+              >
+                <LogIn className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Se connecter
+              </Link>
+              <Link
+                to="/pro/register"
+                className={buttonVariants({ variant: 'solid', size: 'sm' })}
+                aria-label="Créer un compte professionnel"
+              >
+                <UserPlus className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Créer un compte (Pro)
+              </Link>
+            </div>
+
             {/* Actions */}
             <div className="flex items-center gap-2">
               <AccessibilityToolbar />
@@ -344,6 +366,35 @@ export default function Layout({ children, currentPageName }) {
                   )}
                 </div>
               ))}
+
+              {/* Auth links — mobile */}
+              <hr className="my-2 border-border" />
+              <Link
+                to="/login"
+                className={buttonVariants({ variant: 'ghost' })}
+                onClick={() => setMobileMenuOpen(false)}
+                aria-label="Se connecter"
+              >
+                <LogIn className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Se connecter
+              </Link>
+              <Link
+                to="/pro/register"
+                className={buttonVariants({ variant: 'solid' })}
+                onClick={() => setMobileMenuOpen(false)}
+                aria-label="Créer un compte professionnel"
+              >
+                <UserPlus className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Créer un compte (Pro)
+              </Link>
+              <Link
+                to="/pro/login"
+                className="flex items-center gap-3 px-4 py-3 rounded-lg text-text-body hover:bg-brand-highlight/10 hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-inset"
+                onClick={() => setMobileMenuOpen(false)}
+                aria-label="Accéder à l'espace professionnel"
+              >
+                Espace Pro
+              </Link>
             </nav>
           </div>
         )}


### PR DESCRIPTION
## HOTFIX — Auth links visibles en prod (Layout header)

### Problème

Les liens d'authentification ("Se connecter", "Créer un compte") étaient ajoutés dans `src/components/layout/Header.jsx` (PR #241), mais ce composant **n'est importé nulle part**. Le vrai header de production est dans `src/pages/Layout.jsx` — les liens n'étaient donc jamais visibles en prod.

### Correction

Ajout des liens auth directement dans `src/pages/Layout.jsx` :

**Desktop** (≥ 1024px) — zone d'actions à droite :
- « Se connecter » → `/login` (style `ghost`)
- « Créer un compte (Pro) » → `/pro/register` (style `solid`)

**Mobile** (menu hamburger) — après les items de navigation :
- Séparateur `<hr>`
- « Se connecter » → `/login`
- « Créer un compte (Pro) » → `/pro/register`
- « Espace Pro » → `/pro/login` (lien discret)

### Ce qui ne change PAS
- ✅ `/admin/login` **non exposé** dans le header public
- ✅ 0 dépendance ajoutée
- ✅ 0 changement backend/auth
- ✅ `src/components/layout/Header.jsx` non modifié (laissé tel quel)
- ✅ `focus-visible` géré via `buttonVariants` (ring-2 + ring-offset-2)
- ✅ Liens sémantiques `<Link>` (react-router = `<a>`)

### Fichier modifié
| Fichier | Changement |
|---|---|
| `src/pages/Layout.jsx` | +53 lignes (auth links desktop + mobile) |

### Vérifications

| Check | Résultat |
|---|---|
| `npm run lint` | ✅ 0 errors |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ 86 fichiers, 370 tests |
| `npm run build` | ✅ |