### PR TITLE
P0-05 — Supprimer 'Non renseigné' partout + standardiser les états vides (policy Masquer)

### DIFF
--- a/src/components/ProvenanceFreshness.jsx
+++ b/src/components/ProvenanceFreshness.jsx
@@ -36,23 +36,27 @@ export default function ProvenanceFreshness({ provenance }) {
         </div>
 
         <dl className="space-y-3 text-sm">
-          <div className="flex items-start justify-between gap-4">
-            <dt className="font-medium text-slate-700">Dernière vérification</dt>
-            <dd className="text-slate-900">{verifiedAt || 'Non renseigné'}</dd>
-          </div>
+          {verifiedAt && (
+            <div className="flex items-start justify-between gap-4">
+              <dt className="font-medium text-slate-700">Dernière vérification</dt>
+              <dd className="text-slate-900">{verifiedAt}</dd>
+            </div>
+          )}
 
-          <div className="flex items-start justify-between gap-4">
-            <dt className="font-medium text-slate-700 flex items-center gap-1">
-              <Calendar className="h-4 w-4" aria-hidden="true" />
-              Dernière collecte
-            </dt>
-            <dd className="text-slate-900">{fetchedAt || 'Non renseigné'}</dd>
-          </div>
+          {fetchedAt && (
+            <div className="flex items-start justify-between gap-4">
+              <dt className="font-medium text-slate-700 flex items-center gap-1">
+                <Calendar className="h-4 w-4" aria-hidden="true" />
+                Dernière collecte
+              </dt>
+              <dd className="text-slate-900">{fetchedAt}</dd>
+            </div>
+          )}
 
-          <div className="flex items-start justify-between gap-4">
-            <dt className="font-medium text-slate-700">Source</dt>
-            <dd className="text-right text-slate-900">
-              {normalized.sourceUrl ? (
+          {normalized.sourceUrl && (
+            <div className="flex items-start justify-between gap-4">
+              <dt className="font-medium text-slate-700">Source</dt>
+              <dd className="text-right text-slate-900">
                 <a
                   href={normalized.sourceUrl}
                   target="_blank"
@@ -63,11 +67,9 @@ export default function ProvenanceFreshness({ provenance }) {
                   {normalized.sourceHost || 'Voir la source'}
                   <ExternalLink className="h-3 w-3" aria-hidden="true" />
                 </a>
-              ) : (
-                'Non renseignée'
-              )}
-            </dd>
-          </div>
+              </dd>
+            </div>
+          )}
         </dl>
 
         <p className="text-xs text-slate-600">

--- a/src/components/cards/AideCard.jsx
+++ b/src/components/cards/AideCard.jsx
@@ -57,7 +57,7 @@ export default function AideCard({ aide, compact = false }) {
   const sourceHost = provenance.sourceHost;
   const freshness = getFreshnessBadge(provenance.verifiedAt);
   const verificationLabel = verifiedAt ? `Vérifié le ${verifiedAt}` : 'À vérifier';
-  const sourceLabel = sourceHost ? `Source: ${sourceHost}` : 'Source: non renseignée';
+  const sourceLabel = sourceHost ? `Source: ${sourceHost}` : null;
 
   const categorySlug = (() => {
     const raw = aide?.categorie || aide?.theme || aide?.category?.slug || aide?.category_code;
@@ -148,10 +148,12 @@ export default function AideCard({ aide, compact = false }) {
               <Calendar className="h-4 w-4" />
               {verificationLabel}
             </span>
-            <span className="flex items-center gap-1">
-              <CheckCircle2 className="h-4 w-4" />
-              {sourceLabel}
-            </span>
+            {sourceLabel && (
+              <span className="flex items-center gap-1">
+                <CheckCircle2 className="h-4 w-4" />
+                {sourceLabel}
+              </span>
+            )}
           </div>
 
           {/* Visual Link (Not interactive, just decoration) */}

--- a/src/components/cards/DemarcheCard.jsx
+++ b/src/components/cards/DemarcheCard.jsx
@@ -23,7 +23,7 @@ export default function DemarcheCard({ demarche }) {
   const sourceHost = provenance.sourceHost;
   const freshness = getFreshnessBadge(provenance.verifiedAt);
   const verificationLabel = verifiedAt ? `Vérifié le ${verifiedAt}` : 'À vérifier';
-  const sourceLabel = sourceHost ? `Source: ${sourceHost}` : 'Source: non renseignée';
+  const sourceLabel = sourceHost ? `Source: ${sourceHost}` : null;
   const targetUrl = demarche.slug ? `/demarches/${demarche.slug}` : `/demarches/view?id=${demarche.id}`;
 
   return (
@@ -61,27 +61,29 @@ export default function DemarcheCard({ demarche }) {
           <p className="text-slate-600 text-sm line-clamp-2 mb-6">
             {demarche.summary_falc || demarche.description_courte}
           </p>
-	          <div className="flex flex-wrap gap-4 text-xs text-slate-500">
+          <div className="flex flex-wrap gap-4 text-xs text-slate-500">
             {demarche.delai && (
               <span className="flex items-center gap-1.5">
                 <Clock className="h-3.5 w-3.5" /> {demarche.delai}
               </span>
             )}
-	            <span className="flex items-center gap-1.5">
-	              <CheckCircle2 className="h-3.5 w-3.5 text-green-500" /> Guide pas à pas
-	            </span>
-	          </div>
-            <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-500">
-              <span className="flex items-center gap-1.5">
-                <Calendar className="h-3.5 w-3.5" />
-                {verificationLabel}
-              </span>
+            <span className="flex items-center gap-1.5">
+              <CheckCircle2 className="h-3.5 w-3.5 text-green-500" /> Guide pas à pas
+            </span>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-500">
+            <span className="flex items-center gap-1.5">
+              <Calendar className="h-3.5 w-3.5" />
+              {verificationLabel}
+            </span>
+            {sourceLabel && (
               <span className="flex items-center gap-1.5">
                 <CheckCircle2 className="h-3.5 w-3.5 text-blue-600" />
                 {sourceLabel}
               </span>
-            </div>
-	        </div>
+            )}
+          </div>
+        </div>
         <div className="bg-slate-50 px-6 py-3 border-t border-slate-100">
           <div
             className="inline-flex items-center gap-2 text-blue-600 font-bold text-sm group-hover:text-blue-800 transition-colors"


### PR DESCRIPTION
## P0-05 — Supprimer "Non renseigné" + standardiser les états vides

### Inventaire des occurrences remplacées

| # | Fichier | Ligne | Contexte | Avant | Après |
|---|---|---|---|---|---|
| 1 | `ProvenanceFreshness.jsx` | L41 | Date `verifiedAt` absente | `'Non renseigné'` | Ligne masquée |
| 2 | `ProvenanceFreshness.jsx` | L49 | Date `fetchedAt` absente | `'Non renseigné'` | Ligne masquée |
| 3 | `ProvenanceFreshness.jsx` | L67 | `sourceUrl` absent | `'Non renseignée'` | Ligne masquée |
| 4 | `AideCard.jsx` | L60 | `sourceHost` absent | `'Source: non renseignée'` | Ligne masquée |
| 5 | `DemarcheCard.jsx` | L26 | `sourceHost` absent | `'Source: non renseignée'` | Ligne masquée |

### Policy choisie : **B — Masquer la ligne**

Quand une donnée est absente (date, source), la ligne correspondante est **masquée** (pas de texte trompeur). Appliquée de manière cohérente sur :
- ✅ Listing Aides (`AideCard`)
- ✅ Listing Démarches (`DemarcheCard`)
- ✅ Détail Aide/Démarche (`ProvenanceFreshness`)
- ✅ Admin (même composants réutilisés)

### Fichiers modifiés (3 fichiers, +44/-38 lignes)

| Fichier | Changement |
|---|---|
| `src/components/ProvenanceFreshness.jsx` | 3 blocs conditionnels (verifiedAt, fetchedAt, sourceUrl) |
| `src/components/cards/AideCard.jsx` | sourceLabel → null + span conditionnel |
| `src/components/cards/DemarcheCard.jsx` | sourceLabel → null + span conditionnel |

### Vérification

```bash
# Zéro occurrence UI restante (les commentaires policy restent comme documentation)
grep -rni "non renseigné" src/ --include="*.jsx" --include="*.tsx" | grep -v "//\|/\*\|\*"
# → aucun résultat
```

| Check | Résultat |
|---|---|
| `npm run lint` | ✅ 0 errors (1 warning pré-existant) |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ 86 fichiers, 370 tests |
| `npm run build` | ✅ |

### Notes
- Pas de stories ajoutées car aucune story n'existait pour ces composants
- Les commentaires dans `src/lib/trust/policy.ts`, `src/lib/trust/normalize.ts`, `src/lib/trust.ts`, `src/lib/api/mappers.ts` mentionnent "Non renseigné" comme **documentation de la policy** (ex: `Rule: the data layer NEVER fabricates "Non renseigné"`) — ils restent inchangés car ils décrivent l'interdit, pas l'affichage