### PR TITLE
P0-06 — Corriger contrastes + focus invisibles via tokens (WCAG AA)

### DIFF
--- a/src/components/cards/AideCard.jsx
+++ b/src/components/cards/AideCard.jsx
@@ -88,7 +88,7 @@ export default function AideCard({ aide, compact = false }) {
       <Link
         to={targetUrl}
         data-testid={`aide-card-link-${aide.id}`}
-        className="absolute inset-0 z-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-xl"
+        className="absolute inset-0 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
         aria-label={`Voir l'aide ${aide.titre}`}
       >
         <span className="sr-only">Voir l'aide {aide.titre}</span>

--- a/src/components/cards/DispositifCard.jsx
+++ b/src/components/cards/DispositifCard.jsx
@@ -2,47 +2,47 @@ import { Link } from 'react-router-dom';
 import { ExternalLink } from 'lucide-react';
 
 export default function DispositifCard({ dispositif }) {
-  const targetUrl = dispositif.slug ? `/dispositifs/${dispositif.slug}` : `/dispositifs/view?id=${dispositif.id}`;
+    const targetUrl = dispositif.slug ? `/dispositifs/${dispositif.slug}` : `/dispositifs/view?id=${dispositif.id}`;
 
-  return (
-    <div className="bg-white border rounded-lg p-6 shadow-sm hover:shadow-md transition relative group flex flex-col h-full">
-       <Link
-            to={targetUrl}
-            className="absolute inset-0 z-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-lg"
-            aria-label={`Voir le dispositif ${dispositif.titre}`}
-        >
-            <span className="sr-only">Voir le dispositif {dispositif.titre}</span>
-        </Link>
+    return (
+        <div className="bg-white border rounded-lg p-6 shadow-sm hover:shadow-md transition relative group flex flex-col h-full">
+            <Link
+                to={targetUrl}
+                className="absolute inset-0 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg"
+                aria-label={`Voir le dispositif ${dispositif.titre}`}
+            >
+                <span className="sr-only">Voir le dispositif {dispositif.titre}</span>
+            </Link>
 
-        <h2 className="text-xl font-semibold mb-2 text-indigo-700 group-hover:text-indigo-900 transition-colors">
-            {dispositif.titre}
-        </h2>
-        <p className="text-gray-600 mb-4 line-clamp-3 flex-grow">
-            {dispositif.description_falc || "Pas de description disponible."}
-        </p>
+            <h2 className="text-xl font-semibold mb-2 text-indigo-700 group-hover:text-indigo-900 transition-colors">
+                {dispositif.titre}
+            </h2>
+            <p className="text-gray-600 mb-4 line-clamp-3 flex-grow">
+                {dispositif.description_falc || "Pas de description disponible."}
+            </p>
 
-        {dispositif.montant && (
-            <div className="mb-4 text-sm font-medium text-green-700 bg-green-50 p-2 rounded inline-block self-start">
-                💰 {dispositif.montant}
+            {dispositif.montant && (
+                <div className="mb-4 text-sm font-medium text-green-700 bg-green-50 p-2 rounded inline-block self-start">
+                    💰 {dispositif.montant}
+                </div>
+            )}
+
+            {/* Links inside card - keep them clickable with z-20 */}
+            <div className="flex flex-wrap gap-2 mt-auto relative z-20">
+                {dispositif.liens && Array.isArray(dispositif.liens) && dispositif.liens.map((l, idx) => (
+                    <a
+                        key={idx}
+                        href={l.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline text-sm hover:text-blue-800 flex items-center gap-1"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        {l.nom || "En savoir plus"}
+                        <ExternalLink className="h-3 w-3" />
+                    </a>
+                ))}
             </div>
-        )}
-
-        {/* Links inside card - keep them clickable with z-20 */}
-        <div className="flex flex-wrap gap-2 mt-auto relative z-20">
-            {dispositif.liens && Array.isArray(dispositif.liens) && dispositif.liens.map((l, idx) => (
-                <a
-                    key={idx}
-                    href={l.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 underline text-sm hover:text-blue-800 flex items-center gap-1"
-                    onClick={(e) => e.stopPropagation()}
-                >
-                    {l.nom || "En savoir plus"}
-                    <ExternalLink className="h-3 w-3" />
-                </a>
-            ))}
         </div>
-    </div>
-  );
+    );
 }

--- a/src/components/search/AidesSearchForm.jsx
+++ b/src/components/search/AidesSearchForm.jsx
@@ -53,7 +53,7 @@ export default function AidesSearchForm(props) {
           </label>
           <select
             id="aides-search-category"
-            className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+            className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             value={category}
             onChange={(event) => onCategoryChange(event.target.value)}
           >
@@ -72,7 +72,7 @@ export default function AidesSearchForm(props) {
           </label>
           <select
             id="aides-search-limit"
-            className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+            className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             value={String(limit)}
             onChange={(event) => onLimitChange(Number(event.target.value))}
           >

--- a/src/components/search/SearchResultCard.jsx
+++ b/src/components/search/SearchResultCard.jsx
@@ -26,7 +26,7 @@ export default function SearchResultCard({ result }) {
       <h2 className="text-lg font-semibold text-slate-900">
         <Link
           to={targetUrl}
-          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 rounded-sm"
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
         >
           {result.title}
         </Link>
@@ -39,7 +39,7 @@ export default function SearchResultCard({ result }) {
       <div className="mt-4">
         <Link
           to={targetUrl}
-          className="inline-flex items-center gap-2 text-sm font-semibold text-blue-700 hover:text-blue-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 rounded-sm"
+          className="inline-flex items-center gap-2 text-sm font-semibold text-blue-700 hover:text-blue-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
         >
           Voir le détail
           <ArrowRight className="h-4 w-4" />

--- a/src/pages/Actualites.jsx
+++ b/src/pages/Actualites.jsx
@@ -263,7 +263,7 @@ export default function Actualites() {
                     </label>
                     <select
                       id="actualites-source"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={source}
                       onChange={(e) => handleParamChange('source', e.target.value)}
                     >
@@ -281,7 +281,7 @@ export default function Actualites() {
                     </label>
                     <select
                       id="actualites-limit"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={String(limit)}
                       onChange={(e) => handleParamChange('limit', e.target.value)}
                     >
@@ -342,18 +342,18 @@ export default function Actualites() {
             onAction={() => refetch()}
           />
         ) : actualites.length > 0 ? (
-	          <>
-	            <div className="space-y-6" data-testid="actualites-results-list">
-		              {actualites.map((actu) => {
-		                const typeKey = actu.type_actu || 'info';
-		                const TypeIcon = TYPE_ICONS[typeKey] || Info;
+          <>
+            <div className="space-y-6" data-testid="actualites-results-list">
+              {actualites.map((actu) => {
+                const typeKey = actu.type_actu || 'info';
+                const TypeIcon = TYPE_ICONS[typeKey] || Info;
                 const linkUrl = actu.slug ? `/actualites/${actu.slug}` : `/actualites/view?id=${actu.id}`;
-		                const sourceName = getSourceName(actu);
-		                const sourceUrl = getSourceUrl(actu);
-                    const provenance = getProvenance(actu);
-                    const verifiedAt = formatProvenanceDate(provenance.verifiedAt);
-                    const sourceHost = provenance.sourceHost;
-                    const excerpt = htmlToPlainText(actu.summary_falc || actu.resume || '', { maxLength: 220 });
+                const sourceName = getSourceName(actu);
+                const sourceUrl = getSourceUrl(actu);
+                const provenance = getProvenance(actu);
+                const verifiedAt = formatProvenanceDate(provenance.verifiedAt);
+                const sourceHost = provenance.sourceHost;
+                const excerpt = htmlToPlainText(actu.summary_falc || actu.resume || '', { maxLength: 220 });
 
                 return (
                   <Card
@@ -364,21 +364,21 @@ export default function Actualites() {
                     {/* Overlay Link */}
                     <Link
                       to={linkUrl}
-                      className="absolute inset-0 z-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-xl"
+                      className="absolute inset-0 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
                       aria-label={`Lire l'actualité ${actu.titre}`}
                     >
                       <span className="sr-only">Lire l'actualité {actu.titre}</span>
                     </Link>
 
-	                    <CardContent className="p-6">
-	                      <div className="flex flex-wrap gap-2 mb-3">
-	                        <Badge className={TYPE_COLORS[typeKey] || 'bg-slate-100 text-slate-800'}>
-	                          <TypeIcon className="h-3 w-3 mr-1" />
-	                          {typeKey === 'nouveaute' ? 'Nouveauté'
-	                            : typeKey === 'modification' ? 'Modification'
-	                              : typeKey === 'alerte' ? 'Alerte'
-	                                : 'Information'}
-	                        </Badge>
+                    <CardContent className="p-6">
+                      <div className="flex flex-wrap gap-2 mb-3">
+                        <Badge className={TYPE_COLORS[typeKey] || 'bg-slate-100 text-slate-800'}>
+                          <TypeIcon className="h-3 w-3 mr-1" />
+                          {typeKey === 'nouveaute' ? 'Nouveauté'
+                            : typeKey === 'modification' ? 'Modification'
+                              : typeKey === 'alerte' ? 'Alerte'
+                                : 'Information'}
+                        </Badge>
                         {actu.categorie && (
                           <Badge variant="outline">
                             {CATEGORIES[actu.categorie] || actu.categorie}

--- a/src/pages/Aides.jsx
+++ b/src/pages/Aides.jsx
@@ -308,7 +308,7 @@ export default function Aides() {
                     </label>
                     <select
                       id="aides-category"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={category}
                       onChange={(e) => handleParamChange('category', e.target.value)}
                     >
@@ -327,7 +327,7 @@ export default function Aides() {
                     </label>
                     <select
                       id="aides-situation"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={situation}
                       onChange={(e) => handleParamChange('situation', e.target.value)}
                     >
@@ -346,7 +346,7 @@ export default function Aides() {
                     </label>
                     <select
                       id="aides-territory"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={territory}
                       onChange={(e) => handleParamChange('territory', e.target.value)}
                     >
@@ -364,7 +364,7 @@ export default function Aides() {
                     </label>
                     <select
                       id="aides-sort"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={sort}
                       onChange={(e) => handleParamChange('sort', e.target.value)}
                     >
@@ -382,7 +382,7 @@ export default function Aides() {
                     </label>
                     <select
                       id="aides-limit"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={String(limit)}
                       onChange={(e) => handleParamChange('limit', e.target.value)}
                     >

--- a/src/pages/Annuaire.jsx
+++ b/src/pages/Annuaire.jsx
@@ -204,7 +204,7 @@ export default function Annuaire() {
                     </label>
                     <select
                       id="structures-type"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={type}
                       onChange={(e) => handleParamChange('type', e.target.value)}
                     >
@@ -248,7 +248,7 @@ export default function Annuaire() {
                     </label>
                     <select
                       id="structures-sort"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={sort}
                       onChange={(e) => handleParamChange('sort', e.target.value)}
                     >
@@ -267,7 +267,7 @@ export default function Annuaire() {
                     </label>
                     <select
                       id="structures-limit"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={String(limit)}
                       onChange={(e) => handleParamChange('limit', e.target.value)}
                     >

--- a/src/pages/CompteMessageThread.jsx
+++ b/src/pages/CompteMessageThread.jsx
@@ -153,7 +153,7 @@ export default function CompteMessageThread() {
                 onChange={(event) => setBody(event.target.value)}
                 rows={4}
                 maxLength={2000}
-                className="w-full rounded-md border border-slate-300 bg-white p-3 text-sm focus:border-primary focus:outline-none"
+                className="w-full rounded-md border border-slate-300 bg-white p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 placeholder="Ecrivez votre message..."
               />
               <div className="flex items-center gap-3">

--- a/src/pages/Demarches.jsx
+++ b/src/pages/Demarches.jsx
@@ -223,7 +223,7 @@ export default function Demarches() {
                     </label>
                     <select
                       id="demarches-category"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={category}
                       onChange={(e) => handleParamChange('category', e.target.value)}
                     >
@@ -242,7 +242,7 @@ export default function Demarches() {
                     </label>
                     <select
                       id="demarches-situation"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={situation}
                       onChange={(e) => handleParamChange('situation', e.target.value)}
                     >
@@ -261,7 +261,7 @@ export default function Demarches() {
                     </label>
                     <select
                       id="demarches-sort"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={sort}
                       onChange={(e) => handleParamChange('sort', e.target.value)}
                     >
@@ -279,7 +279,7 @@ export default function Demarches() {
                     </label>
                     <select
                       id="demarches-limit"
-                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       value={String(limit)}
                       onChange={(e) => handleParamChange('limit', e.target.value)}
                     >

--- a/src/pages/pro/MessageThread.jsx
+++ b/src/pages/pro/MessageThread.jsx
@@ -117,7 +117,7 @@ export default function ProMessageThread() {
               onChange={(event) => setBody(event.target.value)}
               rows={4}
               maxLength={2000}
-              className="w-full rounded-md border border-slate-300 bg-white p-3 text-sm focus:border-primary focus:outline-none"
+              className="w-full rounded-md border border-slate-300 bg-white p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               placeholder="Ecrivez votre message..."
             />
             <div className="flex items-center gap-3">


### PR DESCRIPTION
## P0-06 — Corriger contrastes + focus invisibles via tokens (WCAG AA)

### Baseline (sur main)

| Check | Résultat |
|---|---|
| `build-storybook` | ✅ |
| `test-storybook` | ✅ 14 suites, 52 tests, 0 axe violations |
| `--muted-foreground` ratio sur blanc | ~4.6:1 → **passe AA** (≥4.5:1) |

→ Aucun changement de valeur de token nécessaire.

### Violations corrigées

#### A) Focus hardcodé → token (21 éléments dans 8 fichiers)

**Pattern incorrect** : `focus:outline-none focus:ring-2 focus:ring-blue-500`
**Correction** : `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`

| Fichier | Éléments corrigés |
|---|---|
| `Aides.jsx` | 5 `<select>` |
| `Annuaire.jsx` | 3 `<select>` |
| `Demarches.jsx` | 4 `<select>` |
| `Actualites.jsx` | 2 `<select>` + 1 card `<Link>` |
| `AideCard.jsx` | 1 card overlay `<Link>` |
| `DispositifCard.jsx` | 1 card overlay `<Link>` |
| `SearchResultCard.jsx` | 2 `<Link>` |
| `AidesSearchForm.jsx` | 2 `<select>` |

#### B) Focus invisible → ring ajouté (2 textareas)

**Pattern incorrect** : `focus:border-primary focus:outline-none` (aucun anneau visible)
**Correction** : `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`

| Fichier | Élément |
|---|---|
| `CompteMessageThread.jsx` | 1 `<textarea>` |
| `pro/MessageThread.jsx` | 1 `<textarea>` |

### Fichiers modifiés (10 fichiers, +80/-80 lignes)

Uniquement des swaps de classes CSS — aucune logique, aucun composant, aucun token modifié.

### Vérification complète

| Check | Résultat |
|---|---|
| `npm run lint` | ✅ 0 errors |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ 86 fichiers, 370 tests |
| `npm run build` | ✅ |
| `npm run build-storybook` | ✅ |
| `npm run test-storybook` | ✅ 14 suites, 52 tests, 0 axe violations |

### Vérification manuelle post-merge

```bash
# Aucun focus:ring-blue hardcodé restant dans les pages/composants corrigés
grep -rn 'focus:ring-blue-500\|focus:ring-blue-600' src/pages/ src/components/cards/ src/components/search/
# → attendu: aucun résultat
```

Navigation clavier : Tab sur un filtre select / carte / textarea → anneau visible via token `--ring`.