### PR TITLE
P1-03 — Test a11y navigation (Header links + focus-visible) bloquant

### DIFF
--- a/tests/a11y/navigation.spec.ts
+++ b/tests/a11y/navigation.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+import { expectNoA11yIssues } from './a11y.utils';
+
+test.describe('Navigation a11y — Header links + focus-visible', () => {
+    test('header navigation contains accessible links', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.goto('/', { waitUntil: 'networkidle' });
+        await page.waitForSelector('header', { state: 'attached' });
+
+        // Verify at least 3 links exist in the header area
+        const headerLinks = page.locator('header').getByRole('link');
+        const linkCount = await headerLinks.count();
+        expect(linkCount, 'Header should contain at least 3 links').toBeGreaterThanOrEqual(3);
+
+        // Verify key navigation labels are present (role-based selectors)
+        const expectedLabels = ['Accueil', 'Aides', 'Démarches'];
+        for (const label of expectedLabels) {
+            const link = page.locator('header').getByRole('link', { name: label }).first();
+            await expect(
+                link,
+                `Header should contain a link with label "${label}"`,
+            ).toBeVisible();
+        }
+    });
+
+    test('keyboard focus reaches header links with visible indicator', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.goto('/', { waitUntil: 'networkidle' });
+        await page.waitForSelector('header', { state: 'attached' });
+
+        const focusedElements: Array<{ tag: string; text: string; hasFocusIndicator: boolean }> = [];
+
+        // Tab through the page — header links/buttons should be in natural tab order
+        for (let i = 0; i < 15; i++) {
+            await page.keyboard.press('Tab');
+            // Small wait for focus styles to apply
+            await page.waitForTimeout(50);
+
+            const focusInfo = await page.evaluate(() => {
+                const el = document.activeElement;
+                if (!el || el === document.body) {
+                    return null;
+                }
+
+                const tag = el.tagName.toLowerCase();
+                // Only care about interactive elements
+                if (tag !== 'a' && tag !== 'button') return null;
+
+                // Check if element is within the header
+                if (!el.closest('header')) return null;
+
+                const text = (el.textContent || '').trim().substring(0, 30);
+
+                // Check focus indicator via computed styles
+                // Tailwind ring utility uses box-shadow; browser focus uses outline
+                const style = window.getComputedStyle(el);
+                const hasOutline = style.outlineStyle !== 'none' && style.outlineWidth !== '0px';
+                const hasBoxShadow = style.boxShadow !== 'none' && style.boxShadow !== '';
+                const hasFocusIndicator = hasOutline || hasBoxShadow;
+
+                return { tag, text, hasFocusIndicator };
+            });
+
+            if (focusInfo) {
+                focusedElements.push(focusInfo);
+            }
+        }
+
+        // Verify: at least 3 interactive header elements received focus
+        expect(
+            focusedElements.length,
+            `At least 3 header links/buttons should receive keyboard focus, got ${focusedElements.length}: [${focusedElements.map((e) => e.text).join(', ')}]`,
+        ).toBeGreaterThanOrEqual(3);
+
+        // Verify: every focused element had a visible focus indicator
+        const withoutIndicator = focusedElements.filter((e) => !e.hasFocusIndicator);
+        expect(
+            withoutIndicator.length,
+            `All focused header elements should have a visible focus indicator (outline or box-shadow). Missing on: [${withoutIndicator.map((e) => e.text).join(', ')}]`,
+        ).toBe(0);
+    });
+
+    test('no critical/serious a11y violations on Home page (Axe)', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.goto('/', { waitUntil: 'networkidle' });
+        await page.waitForSelector('header', { state: 'attached' });
+        await expectNoA11yIssues(page);
+    });
+
+    test('mobile: header navigation accessible via hamburger menu', async ({ page }) => {
+        // Set mobile viewport BEFORE navigating
+        await page.setViewportSize({ width: 375, height: 667 });
+        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.waitForSelector('header', { state: 'attached', timeout: 15000 });
+
+        // Find and click the mobile menu toggle button
+        const menuButton = page.locator('header').getByRole('button', { name: /menu|ouvrir/i });
+        await expect(menuButton).toBeVisible({ timeout: 10000 });
+        await menuButton.click();
+
+        // Wait for mobile nav to appear
+        await page.waitForTimeout(300);
+
+        // Verify at least one navigation link became visible after opening menu
+        // The mobile nav renders links that were previously hidden
+        const mobileNavLinks = page.locator('header nav[aria-label*="mobile" i] a, header nav[aria-label*="Mobile" i] a');
+        const visibleCount = await mobileNavLinks.count();
+        expect(
+            visibleCount,
+            'Mobile menu should show navigation links after opening',
+        ).toBeGreaterThanOrEqual(1);
+
+        // Verify a specific nav item is visible (Accueil)
+        const accueilLink = mobileNavLinks.filter({ hasText: 'Accueil' });
+        await expect(accueilLink.first()).toBeVisible();
+
+        // Run Axe on mobile view with menu open
+        await expectNoA11yIssues(page);
+    });
+});


### PR DESCRIPTION
## P1-03 — Test a11y navigation (Header links + focus-visible) bloquant

### Objectif

Ajouter un test Playwright + Axe bloquant qui vérifie l'accessibilité de la navigation (header links, focus-visible, hamburger mobile).

### Fichier ajouté (1 fichier, +120 lignes)

| Fichier | Action |
|---------|--------|
| `tests/a11y/navigation.spec.ts` | **[NEW]** 4 tests navigation a11y |

### Scénarios testés

| # | Test | Détail |
|---|------|--------|
| 1 | **Header links** | Vérifie ≥3 liens dans le header (Accueil, Aides, Démarches) via `getByRole('link')` |
| 2 | **Keyboard focus** | Tab 15× → vérifie ≥3 liens/boutons header reçoivent le focus avec indicateur visible (outline ou box-shadow via `computedStyle`) |
| 3 | **Axe scan** | Scan Axe complet sur Home → bloque si violations `critical`/`serious` |
| 4 | **Mobile hamburger** | Viewport 375px → click hamburger → vérifie liens nav visibles dans `nav[aria-label*=mobile]` → Axe scan mobile |

### Injection Axe

Utilise le helper existant `tests/a11y/a11y.utils.ts` → `expectNoA11yIssues(page)` qui :
- Injecte `@axe-core/playwright` (`AxeBuilder`)
- Filtre sur `impact === 'critical' || impact === 'serious'`
- Log clair en cas d'échec (nombre + nœuds ciblés)

### Vérification focus : approche retenue

**`computedStyle`** (la plus robuste) :
```ts
const hasOutline = style.outlineStyle !== 'none' && style.outlineWidth !== '0px';
const hasBoxShadow = style.boxShadow !== 'none' && style.boxShadow !== '';
```
Pourquoi : Tailwind `ring-*` utilise `box-shadow`, le browser focus natif utilise `outline`. Cette approche couvre les deux sans dépendre de classes CSS spécifiques → pas de faux positifs si le DS évolue.

### Vérification complète

| Commande | Résultat |
|----------|---------|
| `npm run lint` | ✅ 0 errors |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ 370/370 |
| `npm run test:a11y` | ✅ **6 tests passed** (4 nouveaux + 2 existants, 14.6s) |

### Périmètre respecté

- ✅ ZÉRO changement `src/**` (aucun fichier applicatif modifié)
- ✅ ZÉRO nouvelle dépendance npm
- ✅ ZÉRO modification tailwind/storybook/CI
- ✅ Réutilise `@axe-core/playwright` + `a11y.utils.ts` existants
- ✅ Commit unique
- ✅ Selectors robustes (roles, aria-labels) — pas flaky