### PR TITLE
P2-10.2 — Brancher /orientation + ChatAssistant sur /api/assistant/chat (fin du mock)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -146,3 +146,10 @@ curl -X POST https://<domain>/api/assistant/chat \
 
 - Les données sensibles (NIR, IBAN, numéro de carte bancaire) sont détectées et bloquées côté serveur avant tout appel à Gemini.
 - Le modèle utilise `temperature: 0.2` et des instructions système strictes pour éviter les hallucinations.
+
+### Tester l'interface
+
+1. S'assurer que `GEMINI_API_KEY` est défini dans `.env.local`
+2. Lancer `npm run dev`
+3. Naviguer vers `/orientation` — le chat est embarqué dans la page
+4. Le composant `ChatAssistant` est aussi disponible en widget flottant (sans prop `embedded`)

--- a/src/components/chat/ChatAssistant.jsx
+++ b/src/components/chat/ChatAssistant.jsx
@@ -1,48 +1,129 @@
-import { useEffect, useRef, useState } from 'react';
-import { MessageCircle, Send, X } from 'lucide-react';
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { MessageCircle, Send, X, Loader2, RefreshCw } from 'lucide-react';
+import { sendMessage, AssistantError } from '@/lib/assistant/client';
 
-export default function ChatAssistant() {
-  const [isOpen, setIsOpen] = useState(false);
+/**
+ * @param {{ embedded?: boolean }} props
+ *   - embedded: if true, renders inline (for Orientation page); default false = floating widget
+ */
+export default function ChatAssistant({ embedded = false }) {
+  const [isOpen, setIsOpen] = useState(embedded);
   const [inputValue, setInputValue] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(/** @type {string | null} */(null));
   const [messages, setMessages] = useState([
     {
       id: 1,
       role: 'assistant',
-      content: 'Bonjour, je peux vous aider a vous orienter.',
+      content: 'Bonjour, je peux vous aider à trouver les aides adaptées à votre situation.',
     },
   ]);
   const endOfMessagesRef = useRef(null);
+  const inputRef = useRef(null);
+  /** @type {import('react').MutableRefObject<AbortController | null>} */
+  const abortRef = useRef(null);
 
   useEffect(() => {
     endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, isOpen]);
+  }, [messages, isOpen, isLoading]);
 
-  const handleSubmit = (event) => {
-    event.preventDefault();
-    const trimmedValue = inputValue.trim();
-    if (!trimmedValue) return;
+  // Cleanup abort controller on unmount
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
 
-    setMessages((currentMessages) => [
-      ...currentMessages,
-      {
-        id: Date.now(),
-        role: 'user',
-        content: trimmedValue,
-      },
-      {
-        id: Date.now() + 1,
-        role: 'assistant',
-        content: 'Merci pour votre message. Cette version est uniquement une interface de demonstration.',
-      },
-    ]);
-    setInputValue('');
-  };
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      const trimmedValue = inputValue.trim();
+      if (!trimmedValue || isLoading) return;
 
+      // Clear any previous error
+      setError(null);
+      setInputValue('');
+
+      const userMessageId = Date.now();
+      setMessages((prev) => [
+        ...prev,
+        { id: userMessageId, role: 'user', content: trimmedValue },
+      ]);
+
+      setIsLoading(true);
+
+      // Abort any previous in-flight request
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const response = await sendMessage(trimmedValue, undefined, {
+          signal: controller.signal,
+        });
+
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now(),
+            role: 'assistant',
+            content: response.answer,
+          },
+        ]);
+      } catch (err) {
+        if (err instanceof AssistantError) {
+          setError(err.userMessage);
+        } else if (err instanceof DOMException && err.name === 'AbortError') {
+          // Request was cancelled (e.g. new message sent), don't show error
+          return;
+        } else {
+          setError('Une erreur inattendue est survenue. Veuillez réessayer.');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [inputValue, isLoading],
+  );
+
+  const handleRetry = useCallback(() => {
+    setError(null);
+    // Focus input so user can re-type or modify
+    inputRef.current?.focus();
+  }, []);
+
+  // --- Embedded mode: render inline, no FAB ---
+  if (embedded) {
+    return (
+      <section
+        className="flex h-[520px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+        aria-label="Discussion avec l'assistant"
+      >
+        <ChatHeader />
+        <ChatMessages
+          messages={messages}
+          isLoading={isLoading}
+          error={error}
+          onRetry={handleRetry}
+          endOfMessagesRef={endOfMessagesRef}
+        />
+        <ChatInput
+          inputValue={inputValue}
+          setInputValue={setInputValue}
+          isLoading={isLoading}
+          onSubmit={handleSubmit}
+          inputRef={inputRef}
+        />
+      </section>
+    );
+  }
+
+  // --- Floating widget mode ---
   return (
     <>
       <button
         type="button"
-        onClick={() => setIsOpen((currentValue) => !currentValue)}
+        onClick={() => setIsOpen((v) => !v)}
         className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
         aria-label={isOpen ? "Fermer l'assistant" : "Ouvrir l'assistant"}
       >
@@ -54,60 +135,127 @@ export default function ChatAssistant() {
           className="fixed bottom-24 right-6 z-50 flex h-[500px] w-[380px] max-h-[calc(100vh-7rem)] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl"
           aria-label="Fenetre de discussion avec l'assistant"
         >
-          <header className="flex items-center justify-between border-b border-slate-200 bg-blue-600 px-4 py-3 text-white">
-            <div>
-              <h2 className="text-sm font-semibold">Assistant AccesDirectAide</h2>
-              <p className="text-xs text-blue-100">Interface presentative</p>
-            </div>
-            <button
-              type="button"
-              onClick={() => setIsOpen(false)}
-              className="rounded-md p-1 text-white transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
-              aria-label="Fermer la fenetre de discussion"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </header>
-
-          <div className="flex-1 space-y-3 overflow-y-auto bg-slate-50 p-4">
-            {messages.map((message) => (
-              <div
-                key={message.id}
-                className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
-              >
-                <div
-                  className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${message.role === 'user'
-                    ? 'bg-blue-600 text-white'
-                    : 'border border-slate-200 bg-white text-slate-700'
-                    }`}
-                >
-                  {message.content}
-                </div>
-              </div>
-            ))}
-            <div ref={endOfMessagesRef} />
-          </div>
-
-          <form onSubmit={handleSubmit} className="flex items-center gap-2 border-t border-slate-200 bg-white p-3">
-            <input
-              type="text"
-              value={inputValue}
-              onChange={(event) => setInputValue(event.target.value)}
-              placeholder="Ecrivez votre message..."
-              className="h-10 flex-1 rounded-md border border-slate-300 px-3 text-sm text-slate-900 placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
-              aria-label="Message utilisateur"
-            />
-            <button
-              type="submit"
-              disabled={!inputValue.trim()}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md bg-blue-600 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label="Envoyer le message"
-            >
-              <Send className="h-4 w-4" />
-            </button>
-          </form>
+          <ChatHeader onClose={() => setIsOpen(false)} />
+          <ChatMessages
+            messages={messages}
+            isLoading={isLoading}
+            error={error}
+            onRetry={handleRetry}
+            endOfMessagesRef={endOfMessagesRef}
+          />
+          <ChatInput
+            inputValue={inputValue}
+            setInputValue={setInputValue}
+            isLoading={isLoading}
+            onSubmit={handleSubmit}
+            inputRef={inputRef}
+          />
         </section>
       )}
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function ChatHeader({ onClose }) {
+  return (
+    <header className="flex items-center justify-between border-b border-slate-200 bg-blue-600 px-4 py-3 text-white">
+      <div>
+        <h2 className="text-sm font-semibold">Assistant AccesDirectAide</h2>
+        <p className="text-xs text-blue-100">Propulsé par Gemini</p>
+      </div>
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md p-1 text-white transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+          aria-label="Fermer la fenetre de discussion"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </header>
+  );
+}
+
+function ChatMessages({ messages, isLoading, error, onRetry, endOfMessagesRef }) {
+  return (
+    <div className="flex-1 space-y-3 overflow-y-auto bg-slate-50 p-4" role="log" aria-live="polite">
+      {messages.map((message) => (
+        <div
+          key={message.id}
+          className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+        >
+          <div
+            className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${message.role === 'user'
+                ? 'bg-blue-600 text-white'
+                : 'border border-slate-200 bg-white text-slate-700'
+              }`}
+          >
+            {message.content}
+          </div>
+        </div>
+      ))}
+
+      {isLoading && (
+        <div className="flex justify-start">
+          <div className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            <span>Réflexion en cours…</span>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex justify-start">
+          <div className="flex max-w-[85%] flex-col gap-2 rounded-2xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            <p>{error}</p>
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex items-center gap-1 self-start rounded-md px-2 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+            >
+              <RefreshCw className="h-3 w-3" aria-hidden="true" />
+              Réessayer
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div ref={endOfMessagesRef} />
+    </div>
+  );
+}
+
+function ChatInput({ inputValue, setInputValue, isLoading, onSubmit, inputRef }) {
+  return (
+    <form onSubmit={onSubmit} className="flex items-center gap-2 border-t border-slate-200 bg-white p-3">
+      <input
+        ref={inputRef}
+        type="text"
+        value={inputValue}
+        onChange={(event) => setInputValue(event.target.value)}
+        placeholder="Ecrivez votre question…"
+        maxLength={800}
+        disabled={isLoading}
+        className="h-10 flex-1 rounded-md border border-slate-300 px-3 text-sm text-slate-900 placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Message utilisateur"
+      />
+      <button
+        type="submit"
+        disabled={!inputValue.trim() || isLoading}
+        className="inline-flex h-10 w-10 items-center justify-center rounded-md bg-blue-600 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Envoyer le message"
+      >
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        ) : (
+          <Send className="h-4 w-4" />
+        )}
+      </button>
+    </form>
   );
 }

--- a/src/lib/assistant/client.ts
+++ b/src/lib/assistant/client.ts
@@ -1,0 +1,155 @@
+/**
+ * Assistant API client.
+ *
+ * Typed POST wrapper for /api/assistant/chat with 15s timeout.
+ * No external dependencies — native fetch only.
+ */
+
+import { getApiBaseUrl } from '../api/config';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AssistantContext {
+    territory?: string;
+    lang?: 'fr' | 'en';
+    page?: string;
+    wizard?: Record<string, unknown>;
+}
+
+export interface AssistantRequest {
+    message: string;
+    context?: AssistantContext;
+}
+
+export interface AssistantCitation {
+    label: string;
+    url?: string;
+}
+
+export interface AssistantResponse {
+    answer: string;
+    citations?: AssistantCitation[];
+    meta: {
+        model: string;
+        rulepack: string;
+        requestId: string;
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export class AssistantError extends Error {
+    status: number;
+    code: string;
+    userMessage: string;
+
+    constructor(status: number, code: string, userMessage: string) {
+        super(userMessage);
+        this.name = 'AssistantError';
+        this.status = status;
+        this.code = code;
+        this.userMessage = userMessage;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_TIMEOUT_MS = 15_000;
+const ENDPOINT = '/api/assistant/chat';
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a message to the assistant API.
+ *
+ * @throws {AssistantError} on HTTP error, timeout, or network failure
+ */
+export async function sendMessage(
+    message: string,
+    context?: AssistantContext,
+    options?: { signal?: AbortSignal },
+): Promise<AssistantResponse> {
+    const url = `${getApiBaseUrl()}${ENDPOINT}`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), ASSISTANT_TIMEOUT_MS);
+
+    // Honour caller-provided signal (e.g. React unmount).
+    if (options?.signal) {
+        options.signal.addEventListener('abort', () => controller.abort(), {
+            once: true,
+        });
+    }
+
+    const body: AssistantRequest = { message };
+    if (context) body.context = context;
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal,
+        });
+    } catch (error: unknown) {
+        clearTimeout(timeoutId);
+        if (error instanceof DOMException && error.name === 'AbortError') {
+            throw new AssistantError(
+                0,
+                'timeout',
+                'L\'assistant met trop de temps à répondre. Veuillez réessayer.',
+            );
+        }
+        throw new AssistantError(
+            0,
+            'network_error',
+            'Impossible de contacter l\'assistant. Vérifiez votre connexion.',
+        );
+    } finally {
+        clearTimeout(timeoutId);
+    }
+
+    // ---------- Parse response ----------
+    let data: Record<string, unknown>;
+    try {
+        data = (await response.json()) as Record<string, unknown>;
+    } catch {
+        throw new AssistantError(
+            response.status,
+            'invalid_response',
+            'Réponse invalide du serveur.',
+        );
+    }
+
+    // ---------- HTTP errors ----------
+    if (!response.ok) {
+        const code = (typeof data.error === 'string' ? data.error : 'unknown') as string;
+        const msg = (typeof data.message === 'string' ? data.message : undefined) as string | undefined;
+
+        if (response.status === 429) {
+            throw new AssistantError(429, code, msg || 'Trop de messages envoyés. Veuillez patienter.');
+        }
+        if (response.status === 400) {
+            throw new AssistantError(400, code, msg || 'Message invalide.');
+        }
+        throw new AssistantError(
+            response.status,
+            code,
+            msg || 'Une erreur est survenue. Veuillez réessayer.',
+        );
+    }
+
+    return data as unknown as AssistantResponse;
+}

--- a/src/pages/Orientation.jsx
+++ b/src/pages/Orientation.jsx
@@ -1,8 +1,9 @@
 
 import SEO from '@/components/SEO';
 import { Link } from 'react-router-dom';
-import { ArrowRight, Bot } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import ChatAssistant from '@/components/chat/ChatAssistant';
 
 export default function Orientation() {
   return (
@@ -13,29 +14,27 @@ export default function Orientation() {
         path="/orientation"
         noindex
       />
-      <section className="mx-auto max-w-5xl px-4 py-12 sm:px-6">
-        <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-          <div className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-50 text-blue-600">
-            <Bot className="h-5 w-5" />
-          </div>
-          <h1 className="text-3xl font-bold text-slate-900">Mon Assistant</h1>
-          <p className="mt-3 text-slate-600">
-            Fonctionnalite bientot disponible. En attendant, vous pouvez trouver les aides, les demarches et les structures depuis les rubriques principales.
-          </p>
-          <div className="mt-6 flex flex-wrap gap-3">
-            <Link to="/aides">
-              <Button>Voir les aides</Button>
-            </Link>
-            <Link to="/demarches">
-              <Button variant="outline">Voir les demarches</Button>
-            </Link>
-            <Link to="/annuaire">
-              <Button variant="outline" className="gap-2">
-                Voir l&apos;annuaire
-                <ArrowRight className="h-4 w-4" />
-              </Button>
-            </Link>
-          </div>
+      <section className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
+        <h1 className="mb-2 text-3xl font-bold text-slate-900">Mon Assistant</h1>
+        <p className="mb-6 text-slate-600">
+          Posez vos questions sur les aides sociales. L&apos;assistant vous oriente en fonction de votre situation.
+        </p>
+
+        <ChatAssistant embedded />
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link to="/aides">
+            <Button>Voir les aides</Button>
+          </Link>
+          <Link to="/demarches">
+            <Button variant="outline">Voir les demarches</Button>
+          </Link>
+          <Link to="/annuaire">
+            <Button variant="outline" className="gap-2">
+              Voir l&apos;annuaire
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </Link>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Résumé

Branche le frontend (Orientation + ChatAssistant) sur le vrai endpoint `POST /api/assistant/chat` (P2-10.1). Fin du mock « interface de démonstration ».

## Changements

### Nouveau fichier
- **`src/lib/assistant/client.ts`** — Wrapper fetch typé :
  - `sendMessage(message, context?, options?)` → POST `/api/assistant/chat`
  - Timeout 15s (AI peut être plus lent)
  - `AssistantError` avec `status`, `code`, `userMessage` (messages FR)
  - Abort signal support (React unmount)
  - Zéro dépendance externe

### Fichiers modifiés
- **`src/components/chat/ChatAssistant.jsx`** — Remplace le mock :
  - Appel réel `sendMessage()` au lieu de réponse hardcodée
  - État loading (spinner + « Réflexion en cours… »)
  - État erreur avec message + bouton « Réessayer »
  - Nouveau prop `embedded` : `true` = inline (Orientation), `false` = widget flottant
  - Abort automatique à l'unmount et sur nouveau message
  - Accessibilité : `aria-label`, `aria-live="polite"`, `role="log"`, `focus-visible`
  - Input `maxLength={800}` synchronisé avec la validation serveur

- **`src/pages/Orientation.jsx`** — Remplace le placeholder :
  - Import + `<ChatAssistant embedded />` dans la page
  - Description « Posez vos questions… » au lieu de « bientôt disponible »
  - Liens rapides (aides, démarches, annuaire) conservés

- **`docs/RUNBOOK.md`** — §6 : instructions de test UI

### Non touché
- `src/components/chat/ChatWidget.jsx` — legacy, périmètre séparé
- Backend (`api/**`) — déjà livré en P2-10.1
- Tokens/tailwind/storybook config/CI
- Aucune nouvelle dépendance npm

## Accessibilité
- `aria-label` sur tous les boutons et inputs
- `role="log"` + `aria-live="polite"` sur la zone messages
- `focus-visible` ring sur tous les éléments interactifs
- Navigation clavier complète (Tab/Enter/Escape)

## Preflight
```
✅ npm run lint       (0 errors)
✅ npm run typecheck  (clean)
✅ npm test           (86 files, 370 tests passed)
✅ npm run build      (success)
```

## Test local
```bash
# Nécessite GEMINI_API_KEY dans .env.local pour le backend
npm run dev
# Naviguer vers /orientation
```