### PR TITLE
P2-10.3 — Mon Assistant Wizard V1 (diagnostic guidé + cartes cliquables)

### DIFF
--- a/docs/ASSISTANT.md
+++ b/docs/ASSISTANT.md
@@ -1,0 +1,67 @@
+# Assistant — Documentation technique
+
+## Vue d'ensemble
+
+L'assistant d'orientation (`/orientation`) guide l'utilisateur à travers un wizard en 4 étapes, puis affiche des recommandations personnalisées issues de la recherche ADA.
+
+## Flux du Wizard
+
+```
+Étape 1 — Besoin principal (logement/santé/travail/papiers/urgence)
+     ↓
+Étape 2 — Territoire (ville ou code postal, optionnel)
+     ↓
+Étape 3 — Profil (situation familiale + statut emploi)
+     ↓
+Étape 4 — Urgence + options (handicap/langue/numérique)
+     ↓
+Résultats — Cartes cliquables + plan d'action IA
+```
+
+## Intégration API
+
+### 1. Recommandations — `POST /api/assistant/recommendations`
+
+Appelé à la fin du wizard avec :
+- `need` : label du besoin sélectionné
+- `territory` : code postal/ville (si renseigné)
+- `limit` : 6
+- `types` : `["aide", "demarche", "structure"]`
+
+Renvoie des items réels issus de la base ADA (embedding + lexical search).
+
+### 2. Résumé IA — `POST /api/assistant/chat`
+
+Appelé après les recommandations, en mode non-bloquant :
+- `message` : prompt structuré avec les titres des recommandations
+- `context.wizard` : données du wizard complètes
+
+Le résumé est optionnel — si l'appel échoue, les cartes restent visibles.
+
+## Composants
+
+| Composant | Fichier | Rôle |
+|:----------|:--------|:-----|
+| `Wizard` | `src/components/assistant/Wizard.jsx` | Orchestrateur (state machine) |
+| `StepNeed` | `src/components/assistant/StepNeed.jsx` | Sélection du besoin |
+| `StepTerritory` | `src/components/assistant/StepTerritory.jsx` | Input territoire |
+| `StepProfile` | `src/components/assistant/StepProfile.jsx` | Situation + statut |
+| `StepUrgency` | `src/components/assistant/StepUrgency.jsx` | Urgence + options |
+| `ResultPanel` | `src/components/assistant/ResultPanel.jsx` | Affichage résultats |
+| `RecommendationCard` | `src/components/assistant/RecommendationCard.jsx` | Carte cliquable |
+
+## Accessibilité
+
+- `aria-label` sur tous les groupes et boutons
+- `role="radiogroup"` et `aria-checked` pour les sélections
+- `role="progressbar"` pour la barre de progression
+- `focus-visible` ring sur tous les éléments interactifs
+- Navigation clavier complète (Tab/Enter/Space)
+- Safety note visible interdisant les données sensibles
+
+## Sécurité
+
+- Aucune donnée sensible demandée (pas de NIR, RIB, adresse exacte)
+- Les données du wizard ne sont pas persistées
+- Les recommandations proviennent uniquement de la recherche ADA (pas d'hallucination)
+- Le résumé IA est contraint au contenu des recommandations renvoyées

--- a/src/components/assistant/RecommendationCard.jsx
+++ b/src/components/assistant/RecommendationCard.jsx
@@ -1,0 +1,55 @@
+import { Link } from 'react-router-dom';
+import { ExternalLink, CheckCircle } from 'lucide-react';
+
+const TYPE_LABELS = {
+    aide: 'Aide',
+    demarche: 'Démarche',
+    structure: 'Structure',
+};
+
+const TYPE_COLORS = {
+    aide: 'bg-blue-50 text-blue-700',
+    demarche: 'bg-emerald-50 text-emerald-700',
+    structure: 'bg-amber-50 text-amber-700',
+};
+
+function truncate(text, max = 120) {
+    if (!text) return '';
+    return text.length > max ? text.slice(0, max).trimEnd() + '…' : text;
+}
+
+export default function RecommendationCard({ item }) {
+    const { type, slug, title, excerpt, url, sourceLabel, verifiedAt } = item;
+
+    if (!title || !url) return null;
+
+    return (
+        <Link
+            to={url}
+            className="group block rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition-all hover:border-blue-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+            aria-label={`${TYPE_LABELS[type] || type} : ${title}`}
+        >
+            <div className="mb-2 flex items-start justify-between gap-2">
+                <span className={`inline-flex rounded-md px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[type] || 'bg-slate-100 text-slate-700'}`}>
+                    {TYPE_LABELS[type] || type}
+                </span>
+                <ExternalLink className="h-3.5 w-3.5 shrink-0 text-slate-400 transition-colors group-hover:text-blue-500" aria-hidden="true" />
+            </div>
+            <h3 className="mb-1 text-sm font-semibold text-slate-900 group-hover:text-blue-700">
+                {title}
+            </h3>
+            {excerpt && (
+                <p className="mb-2 text-xs leading-relaxed text-slate-500">{truncate(excerpt)}</p>
+            )}
+            <div className="flex items-center gap-2 text-xs text-slate-400">
+                {sourceLabel && <span>{sourceLabel}</span>}
+                {verifiedAt && (
+                    <span className="inline-flex items-center gap-1">
+                        <CheckCircle className="h-3 w-3 text-emerald-500" aria-hidden="true" />
+                        Vérifié
+                    </span>
+                )}
+            </div>
+        </Link>
+    );
+}

--- a/src/components/assistant/ResultPanel.jsx
+++ b/src/components/assistant/ResultPanel.jsx
@@ -1,0 +1,127 @@
+import { ShieldCheck, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import EmptyState from '@/components/ui/EmptyState';
+import RecommendationCard from './RecommendationCard';
+
+const SECTION_LABELS = {
+    aide: 'Aides recommandées',
+    demarche: 'Démarches à effectuer',
+    structure: 'Structures proches',
+};
+
+function groupByType(items) {
+    const groups = { aide: [], demarche: [], structure: [] };
+    for (const item of items) {
+        if (groups[item.type]) {
+            groups[item.type].push(item);
+        }
+    }
+    return groups;
+}
+
+function LoadingSkeleton() {
+    return (
+        <div className="space-y-6" aria-busy="true" aria-label="Chargement des recommandations">
+            {[1, 2, 3].map((i) => (
+                <div key={i} className="space-y-3">
+                    <Skeleton className="h-5 w-40" />
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        <Skeleton className="h-28 rounded-xl" />
+                        <Skeleton className="h-28 rounded-xl" />
+                    </div>
+                </div>
+            ))}
+            <Skeleton className="mt-4 h-32 rounded-xl" />
+        </div>
+    );
+}
+
+function AISummary({ summary }) {
+    if (!summary) return null;
+
+    return (
+        <div className="mt-6 rounded-xl border border-blue-200 bg-blue-50 p-4">
+            <h3 className="mb-2 text-sm font-semibold text-blue-900">Plan d&apos;action suggéré</h3>
+            <div className="text-sm leading-relaxed text-blue-800 whitespace-pre-line">
+                {summary}
+            </div>
+            <div className="mt-3 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+                <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                Ne communiquez jamais de données sensibles (numéro de sécurité sociale, RIB, adresse exacte).
+            </div>
+        </div>
+    );
+}
+
+export default function ResultPanel({ items, summary, isLoading, error, onRetry, onRestart }) {
+    if (isLoading) {
+        return <LoadingSkeleton />;
+    }
+
+    if (error) {
+        return (
+            <EmptyState
+                title="Impossible de charger les recommandations"
+                description={error}
+                actions={
+                    <div className="flex gap-2">
+                        <Button size="sm" onClick={onRetry}>Réessayer</Button>
+                        <Button size="sm" variant="outline" onClick={onRestart}>Recommencer</Button>
+                    </div>
+                }
+            />
+        );
+    }
+
+    if (!items || items.length === 0) {
+        return (
+            <EmptyState
+                title="Aucune recommandation trouvée"
+                description="Nous n'avons pas trouvé de résultats correspondant à votre recherche. Essayez de modifier vos critères."
+                actions={
+                    <Button size="sm" variant="outline" onClick={onRestart}>
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                        Recommencer
+                    </Button>
+                }
+            />
+        );
+    }
+
+    const groups = groupByType(items);
+    const hasAny = Object.values(groups).some((g) => g.length > 0);
+
+    return (
+        <div>
+            <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-slate-900">Vos recommandations</h2>
+                <Button type="button" variant="ghost" size="sm" onClick={onRestart} className="gap-1 text-xs">
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    Recommencer
+                </Button>
+            </div>
+
+            {hasAny ? (
+                <div className="space-y-6">
+                    {Object.entries(SECTION_LABELS).map(([type, label]) => {
+                        const sectionItems = groups[type];
+                        if (!sectionItems || sectionItems.length === 0) return null;
+                        return (
+                            <section key={type} aria-label={label}>
+                                <h3 className="mb-3 text-sm font-medium text-slate-600">{label}</h3>
+                                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                    {sectionItems.map((item, idx) => (
+                                        <RecommendationCard key={item.slug || idx} item={item} />
+                                    ))}
+                                </div>
+                            </section>
+                        );
+                    })}
+                </div>
+            ) : null}
+
+            <AISummary summary={summary} />
+        </div>
+    );
+}

--- a/src/components/assistant/StepNeed.jsx
+++ b/src/components/assistant/StepNeed.jsx
@@ -1,0 +1,31 @@
+import { Home, Heart, Briefcase, FileText, AlertTriangle } from 'lucide-react';
+
+const NEEDS = [
+    { key: 'logement', label: 'Logement', icon: Home, color: 'bg-blue-50 text-blue-600 border-blue-200 hover:bg-blue-100' },
+    { key: 'sante', label: 'Santé', icon: Heart, color: 'bg-rose-50 text-rose-600 border-rose-200 hover:bg-rose-100' },
+    { key: 'travail', label: 'Travail / Emploi', icon: Briefcase, color: 'bg-amber-50 text-amber-600 border-amber-200 hover:bg-amber-100' },
+    { key: 'papiers', label: 'Papiers / Droits', icon: FileText, color: 'bg-emerald-50 text-emerald-600 border-emerald-200 hover:bg-emerald-100' },
+    { key: 'urgence', label: 'Urgence', icon: AlertTriangle, color: 'bg-red-50 text-red-600 border-red-200 hover:bg-red-100' },
+];
+
+export default function StepNeed({ onNext }) {
+    return (
+        <div>
+            <h2 className="mb-1 text-lg font-semibold text-slate-900">Quel est votre besoin principal ?</h2>
+            <p className="mb-5 text-sm text-slate-500">Choisissez la catégorie qui correspond le mieux.</p>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2" role="group" aria-label="Catégorie de besoin">
+                {NEEDS.map(({ key, label, icon: Icon, color }) => (
+                    <button
+                        key={key}
+                        type="button"
+                        onClick={() => onNext({ need: key })}
+                        className={`flex items-center gap-3 rounded-xl border px-4 py-3 text-left text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 ${color}`}
+                    >
+                        <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+                        {label}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/assistant/StepProfile.jsx
+++ b/src/components/assistant/StepProfile.jsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+const SITUATIONS = [
+    { key: 'seul', label: 'Seul(e)' },
+    { key: 'couple', label: 'En couple' },
+    { key: 'famille', label: 'Avec enfant(s)' },
+];
+
+const STATUTS = [
+    { key: 'emploi', label: 'En emploi' },
+    { key: 'chomage', label: 'Sans emploi' },
+    { key: 'etudiant', label: 'Étudiant(e)' },
+    { key: 'retraite', label: 'Retraité(e)' },
+    { key: 'hebergement', label: 'Sans hébergement' },
+];
+
+export default function StepProfile({ onNext, onBack }) {
+    const [situation, setSituation] = useState('');
+    const [statut, setStatut] = useState('');
+
+    const canContinue = situation && statut;
+
+    return (
+        <div>
+            <h2 className="mb-1 text-lg font-semibold text-slate-900">Votre situation</h2>
+            <p className="mb-4 text-sm text-slate-500">Ces informations restent anonymes et ne sont pas enregistrées.</p>
+
+            <fieldset className="mb-4">
+                <legend className="mb-2 text-sm font-medium text-slate-700">Situation familiale</legend>
+                <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Situation familiale">
+                    {SITUATIONS.map(({ key, label }) => (
+                        <button
+                            key={key}
+                            type="button"
+                            role="radio"
+                            aria-checked={situation === key}
+                            onClick={() => setSituation(key)}
+                            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 ${situation === key
+                                    ? 'border-blue-600 bg-blue-50 text-blue-700'
+                                    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+                                }`}
+                        >
+                            {label}
+                        </button>
+                    ))}
+                </div>
+            </fieldset>
+
+            <fieldset className="mb-5">
+                <legend className="mb-2 text-sm font-medium text-slate-700">Statut actuel</legend>
+                <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Statut actuel">
+                    {STATUTS.map(({ key, label }) => (
+                        <button
+                            key={key}
+                            type="button"
+                            role="radio"
+                            aria-checked={statut === key}
+                            onClick={() => setStatut(key)}
+                            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 ${statut === key
+                                    ? 'border-blue-600 bg-blue-50 text-blue-700'
+                                    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+                                }`}
+                        >
+                            {label}
+                        </button>
+                    ))}
+                </div>
+            </fieldset>
+
+            <div className="flex items-center gap-3">
+                <Button type="button" variant="outline" size="sm" onClick={onBack}>Retour</Button>
+                <Button type="button" size="sm" disabled={!canContinue} onClick={() => onNext({ situation, statut })}>
+                    Continuer
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/assistant/StepTerritory.jsx
+++ b/src/components/assistant/StepTerritory.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { MapPin } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function StepTerritory({ onNext, onBack }) {
+    const [value, setValue] = useState('');
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        onNext({ territory: value.trim() || undefined });
+    };
+
+    return (
+        <div>
+            <h2 className="mb-1 text-lg font-semibold text-slate-900">Où habitez-vous ?</h2>
+            <p className="mb-5 text-sm text-slate-500">Ville ou code postal (optionnel — permet d&apos;affiner les résultats).</p>
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="relative">
+                    <MapPin className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+                    <input
+                        type="text"
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                        placeholder="Ex : 75012 ou Marseille"
+                        maxLength={60}
+                        className="h-10 w-full rounded-md border border-slate-300 bg-white pl-10 pr-3 text-sm text-slate-900 placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
+                        aria-label="Ville ou code postal"
+                        autoFocus
+                    />
+                </div>
+                <div className="flex items-center gap-3">
+                    <Button type="button" variant="outline" size="sm" onClick={onBack}>Retour</Button>
+                    <Button type="submit" size="sm">
+                        {value.trim() ? 'Continuer' : 'Passer cette étape'}
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/src/components/assistant/StepUrgency.jsx
+++ b/src/components/assistant/StepUrgency.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+const URGENCIES = [
+    { key: 'today', label: "Aujourd'hui" },
+    { key: '7days', label: 'Dans les 7 jours' },
+    { key: '1month', label: "J'ai le temps (1 mois+)" },
+];
+
+const OPTIONS = [
+    { key: 'handicap', label: 'Situation de handicap' },
+    { key: 'langue', label: 'Besoin de traduction / interprétariat' },
+    { key: 'numerique', label: 'Difficulté avec le numérique' },
+];
+
+export default function StepUrgency({ onNext, onBack }) {
+    const [urgency, setUrgency] = useState('');
+    const [options, setOptions] = useState([]);
+
+    const toggleOption = (key) => {
+        setOptions((prev) =>
+            prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+        );
+    };
+
+    return (
+        <div>
+            <h2 className="mb-1 text-lg font-semibold text-slate-900">Niveau d&apos;urgence</h2>
+            <p className="mb-4 text-sm text-slate-500">Pour prioriser les recommandations.</p>
+
+            <fieldset className="mb-5">
+                <legend className="sr-only">Urgence</legend>
+                <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Niveau d'urgence">
+                    {URGENCIES.map(({ key, label }) => (
+                        <button
+                            key={key}
+                            type="button"
+                            role="radio"
+                            aria-checked={urgency === key}
+                            onClick={() => setUrgency(key)}
+                            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 ${urgency === key
+                                    ? 'border-blue-600 bg-blue-50 text-blue-700'
+                                    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+                                }`}
+                        >
+                            {label}
+                        </button>
+                    ))}
+                </div>
+            </fieldset>
+
+            <fieldset className="mb-5">
+                <legend className="mb-2 text-sm font-medium text-slate-700">Options complémentaires (optionnel)</legend>
+                <div className="space-y-2">
+                    {OPTIONS.map(({ key, label }) => (
+                        <label
+                            key={key}
+                            className="flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 transition-colors hover:bg-slate-50"
+                        >
+                            <input
+                                type="checkbox"
+                                checked={options.includes(key)}
+                                onChange={() => toggleOption(key)}
+                                className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-600"
+                            />
+                            {label}
+                        </label>
+                    ))}
+                </div>
+            </fieldset>
+
+            <div className="flex items-center gap-3">
+                <Button type="button" variant="outline" size="sm" onClick={onBack}>Retour</Button>
+                <Button type="button" size="sm" disabled={!urgency} onClick={() => onNext({ urgency, options })}>
+                    Voir mes recommandations
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/assistant/Wizard.jsx
+++ b/src/components/assistant/Wizard.jsx
@@ -1,0 +1,161 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { postRecommendations, sendMessage, AssistantError } from '@/lib/assistant/client';
+import StepNeed from './StepNeed';
+import StepTerritory from './StepTerritory';
+import StepProfile from './StepProfile';
+import StepUrgency from './StepUrgency';
+import ResultPanel from './ResultPanel';
+
+const NEED_LABELS = {
+    logement: 'logement',
+    sante: 'santé',
+    travail: 'travail emploi',
+    papiers: 'papiers droits administratifs',
+    urgence: 'aide urgente hébergement alimentaire',
+};
+
+const TOTAL_STEPS = 4;
+
+export default function Wizard() {
+    const [step, setStep] = useState(0);
+    const [data, setData] = useState({});
+    const [phase, setPhase] = useState('wizard'); // wizard | loading | results | error
+    const [items, setItems] = useState([]);
+    const [summary, setSummary] = useState(null);
+    const [error, setError] = useState(null);
+    const abortRef = useRef(null);
+
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, []);
+
+    const fetchResults = useCallback(async (wizardData) => {
+        setPhase('loading');
+        setError(null);
+        setSummary(null);
+        setItems([]);
+
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        const needStr = NEED_LABELS[wizardData.need] || wizardData.need;
+
+        try {
+            // 1. Get recommendations
+            const recos = await postRecommendations(
+                {
+                    need: needStr,
+                    territory: wizardData.territory,
+                    limit: 6,
+                    types: ['aide', 'demarche', 'structure'],
+                },
+                { signal: controller.signal },
+            );
+
+            setItems(recos.items || []);
+            setPhase('results');
+
+            // 2. Get AI summary (non-blocking — we show cards first)
+            if (recos.items && recos.items.length > 0) {
+                try {
+                    const itemSummaries = recos.items
+                        .filter((it) => it.title)
+                        .map((it) => `- [${it.type}] ${it.title}`)
+                        .join('\n');
+
+                    const aiResponse = await sendMessage(
+                        `Rédige un plan d'action court basé uniquement sur ces recommandations. Utilise un format : Aujourd'hui / Cette semaine / Ensuite.\n\nRecommandations :\n${itemSummaries}`,
+                        { wizard: wizardData },
+                        { signal: controller.signal },
+                    );
+
+                    setSummary(aiResponse.answer);
+                } catch {
+                    // AI summary is optional — don't fail if it doesn't work
+                }
+            }
+        } catch (err) {
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            setPhase('error');
+            setError(
+                err instanceof AssistantError
+                    ? err.userMessage
+                    : 'Une erreur est survenue. Veuillez réessayer.',
+            );
+        }
+    }, []);
+
+    const handleNext = useCallback(
+        (stepData) => {
+            const merged = { ...data, ...stepData };
+            setData(merged);
+
+            if (step < TOTAL_STEPS - 1) {
+                setStep(step + 1);
+            } else {
+                fetchResults(merged);
+            }
+        },
+        [step, data, fetchResults],
+    );
+
+    const handleBack = useCallback(() => {
+        if (step > 0) setStep(step - 1);
+    }, [step]);
+
+    const handleRestart = useCallback(() => {
+        abortRef.current?.abort();
+        setStep(0);
+        setData({});
+        setPhase('wizard');
+        setItems([]);
+        setSummary(null);
+        setError(null);
+    }, []);
+
+    const handleRetry = useCallback(() => {
+        fetchResults(data);
+    }, [data, fetchResults]);
+
+    const progress = phase === 'wizard' ? ((step + 1) / TOTAL_STEPS) * 100 : 100;
+
+    return (
+        <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+            {/* Progress bar */}
+            {phase === 'wizard' && (
+                <div className="px-6 pt-5">
+                    <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
+                        <span>Étape {step + 1} sur {TOTAL_STEPS}</span>
+                    </div>
+                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100" role="progressbar" aria-valuenow={progress} aria-valuemin={0} aria-valuemax={100}>
+                        <div
+                            className="h-full rounded-full bg-blue-600 transition-all duration-300"
+                            style={{ width: `${progress}%` }}
+                        />
+                    </div>
+                </div>
+            )}
+
+            {/* Content */}
+            <div className="p-6">
+                {phase === 'wizard' && step === 0 && <StepNeed onNext={handleNext} />}
+                {phase === 'wizard' && step === 1 && <StepTerritory onNext={handleNext} onBack={handleBack} />}
+                {phase === 'wizard' && step === 2 && <StepProfile onNext={handleNext} onBack={handleBack} />}
+                {phase === 'wizard' && step === 3 && <StepUrgency onNext={handleNext} onBack={handleBack} />}
+                {(phase === 'loading' || phase === 'results' || phase === 'error') && (
+                    <ResultPanel
+                        items={items}
+                        summary={summary}
+                        isLoading={phase === 'loading'}
+                        error={phase === 'error' ? error : null}
+                        onRetry={handleRetry}
+                        onRestart={handleRestart}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/lib/assistant/client.ts
+++ b/src/lib/assistant/client.ts
@@ -153,3 +153,109 @@ export async function sendMessage(
 
     return data as unknown as AssistantResponse;
 }
+
+// ---------------------------------------------------------------------------
+// Recommendations
+// ---------------------------------------------------------------------------
+
+export interface RecommendationItem {
+    type: 'aide' | 'demarche' | 'structure';
+    slug: string | null;
+    title: string | null;
+    excerpt: string | null;
+    url: string | null;
+    sourceLabel?: string | null;
+    sourceUrl?: string | null;
+    verifiedAt?: string | null;
+}
+
+export interface RecommendationsRequest {
+    need: string;
+    territory?: string;
+    limit?: number;
+    types?: Array<'aide' | 'demarche' | 'structure'>;
+}
+
+export interface RecommendationsResponse {
+    items: RecommendationItem[];
+    meta: {
+        from: string;
+        method: string;
+        requestId: string;
+    };
+}
+
+const RECOS_ENDPOINT = '/api/assistant/recommendations';
+
+/**
+ * Fetch recommendations from the ADA search API.
+ *
+ * @throws {AssistantError} on HTTP error, timeout, or network failure
+ */
+export async function postRecommendations(
+    params: RecommendationsRequest,
+    options?: { signal?: AbortSignal },
+): Promise<RecommendationsResponse> {
+    const url = `${getApiBaseUrl()}${RECOS_ENDPOINT}`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), ASSISTANT_TIMEOUT_MS);
+
+    if (options?.signal) {
+        options.signal.addEventListener('abort', () => controller.abort(), {
+            once: true,
+        });
+    }
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            },
+            body: JSON.stringify(params),
+            signal: controller.signal,
+        });
+    } catch (error: unknown) {
+        clearTimeout(timeoutId);
+        if (error instanceof DOMException && error.name === 'AbortError') {
+            throw new AssistantError(
+                0,
+                'timeout',
+                'La recherche prend trop de temps. Veuillez réessayer.',
+            );
+        }
+        throw new AssistantError(
+            0,
+            'network_error',
+            'Impossible de contacter le serveur. Vérifiez votre connexion.',
+        );
+    } finally {
+        clearTimeout(timeoutId);
+    }
+
+    let data: Record<string, unknown>;
+    try {
+        data = (await response.json()) as Record<string, unknown>;
+    } catch {
+        throw new AssistantError(
+            response.status,
+            'invalid_response',
+            'Réponse invalide du serveur.',
+        );
+    }
+
+    if (!response.ok) {
+        const code = (typeof data.error === 'string' ? data.error : 'unknown') as string;
+        const msg = (typeof data.message === 'string' ? data.message : undefined) as string | undefined;
+        throw new AssistantError(
+            response.status,
+            code,
+            msg || 'Une erreur est survenue. Veuillez réessayer.',
+        );
+    }
+
+    return data as unknown as RecommendationsResponse;
+}

--- a/src/pages/Orientation.jsx
+++ b/src/pages/Orientation.jsx
@@ -3,7 +3,7 @@ import SEO from '@/components/SEO';
 import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import ChatAssistant from '@/components/chat/ChatAssistant';
+import Wizard from '@/components/assistant/Wizard';
 
 export default function Orientation() {
   return (
@@ -17,14 +17,14 @@ export default function Orientation() {
       <section className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
         <h1 className="mb-2 text-3xl font-bold text-slate-900">Mon Assistant</h1>
         <p className="mb-6 text-slate-600">
-          Posez vos questions sur les aides sociales. L&apos;assistant vous oriente en fonction de votre situation.
+          Répondez à quelques questions pour recevoir des recommandations personnalisées.
         </p>
 
-        <ChatAssistant embedded />
+        <Wizard />
 
         <div className="mt-6 flex flex-wrap gap-3">
           <Link to="/aides">
-            <Button>Voir les aides</Button>
+            <Button variant="outline">Voir toutes les aides</Button>
           </Link>
           <Link to="/demarches">
             <Button variant="outline">Voir les demarches</Button>


### PR DESCRIPTION
## Résumé

Wizard d'orientation en 4 étapes + cartes de recommandations cliquables + résumé IA. **Frontend-only — aucun changement backend, aucune nouvelle dépendance.**

## Flux

```
Étape 1 — Besoin (logement/santé/travail/papiers/urgence)
    ↓
Étape 2 — Territoire (ville ou CP, optionnel)
    ↓
Étape 3 — Profil (situation familiale + statut emploi)
    ↓
Étape 4 — Urgence + options (handicap/langue/numérique)
    ↓
Résultats — Cartes cliquables (3 sections) + Plan d'action IA
```

## API Integration

1. `POST /api/assistant/recommendations` → cartes ADA réelles (embedding + lexical)
2. `POST /api/assistant/chat` → résumé IA avec nextSteps (non-bloquant)

Les cartes s'affichent immédiatement ; le résumé IA arrive après (si disponible).

## Fichiers (10)

### Nouveaux (8)
| Fichier | Rôle |
|:--------|:-----|
| `src/components/assistant/Wizard.jsx` | Orchestrateur (state machine 4 étapes) |
| `src/components/assistant/StepNeed.jsx` | 5 boutons catégorie avec icônes |
| `src/components/assistant/StepTerritory.jsx` | Input ville/CP avec skip |
| `src/components/assistant/StepProfile.jsx` | Situation familiale + statut |
| `src/components/assistant/StepUrgency.jsx` | Urgence + options checkbox |
| `src/components/assistant/ResultPanel.jsx` | Cartes groupées + skeleton + empty |
| `src/components/assistant/RecommendationCard.jsx` | Carte cliquable → /aides/:slug etc. |
| `docs/ASSISTANT.md` | Documentation technique |

### Modifiés (2)
| Fichier | Changement |
|:--------|:-----------|
| `src/lib/assistant/client.ts` | Ajout `postRecommendations()` + types |
| `src/pages/Orientation.jsx` | Replace `ChatAssistant` par `Wizard` |

## Accessibilité
- `aria-label` sur tous les groupes et boutons
- `role="radiogroup"` + `aria-checked` pour les sélections
- `role="progressbar"` pour la barre de progression
- `focus-visible` ring sur tous les éléments interactifs
- Safety note visible (pas de données sensibles)

## Sécurité
- Aucune donnée sensible demandée
- Données wizard non persistées
- Recommandations = résultats recherche ADA (pas d'hallucination)
- Résumé IA contraint aux items renvoyés

## Preflight
```
✅ npm run lint       (0 errors)
✅ npm run typecheck  (clean)
✅ npm test           (86 files, 370 tests)
✅ npm run build      (success)
```