### PR TITLE
fix(chat): classify all Gemini API errors as 503 instead of generic 500

### DIFF
--- a/api/_handlers/assistant/chat.js
+++ b/api/_handlers/assistant/chat.js
@@ -166,7 +166,7 @@ export default async function handler(req, res) {
     } catch (error) {
         const errorName = error instanceof Error ? error.name : 'unknown';
         const errorMsg = error instanceof Error ? error.message : String(error);
-        log.error({ msg: 'assistant.chat_failed', errorName, requestId });
+        log.error({ msg: 'assistant.chat_failed', errorName, errorMsg, requestId });
 
         Sentry.captureException(error, {
             tags: {
@@ -175,8 +175,22 @@ export default async function handler(req, res) {
             },
         });
 
-        // Surface missing API key as 503 rather than generic 500
-        if (errorMsg.includes('Missing required environment variable')) {
+        // Classify Gemini / Google AI errors as 503 (service unavailable)
+        // This includes: missing key, invalid key, quota exceeded, model errors, API failures.
+        const isGeminiError =
+            errorMsg.includes('Missing required environment variable') ||
+            errorMsg.includes('API_KEY') ||
+            errorMsg.includes('GoogleGenerativeAI') ||
+            errorMsg.includes('PERMISSION_DENIED') ||
+            errorMsg.includes('RESOURCE_EXHAUSTED') ||
+            errorMsg.includes('quota') ||
+            errorMsg.includes('models/') ||
+            errorName === 'GoogleGenerativeAIError' ||
+            errorName === 'GoogleGenerativeAIFetchError' ||
+            errorName === 'GoogleGenerativeAIRequestInputError' ||
+            errorName === 'GoogleGenerativeAIResponseError';
+
+        if (isGeminiError) {
             return res.status(503).json({
                 ok: false,
                 requestId,


### PR DESCRIPTION
# Hotfix: Chatbot 500 → 503 (Gemini API errors)

## Problème en production

La PR #260 a ajouté un early check pour `GEMINI_API_KEY` absente → 503. Mais quand la clé **est présente** et que l'API Gemini elle-même échoue (clé invalide, quota, permission denied, erreur modèle), l'erreur tombait dans le catch générique → **HTTP 500** + `"erreur interne"`.

**Preuve prod** (post-merge #260) :
```
curl -i -X POST https://www.accesdirectaide.fr/api/assistant/chat \
  -H "Content-Type: application/json" -d '{"message":"Bonjour"}'

HTTP/2 500
x-release-sha: 0e04b072efb146ec3017db981f7ad11c6067b84f
{"ok":false,"error":"internal","message":"Une erreur interne est survenue."}
```

## Correctif

Élargi la classification des erreurs dans `api/_handlers/assistant/chat.js` :
- Toute erreur Google Generative AI (nom d'erreur `GoogleGenerativeAI*` ou message contenant des patterns Google AI) → **503** + JSON stable
- Seules les erreurs non-Gemini restent en 500

Cela garantit que le frontend affiche le fallback UX ("assistant indisponible" + CTA "Aller au diagnostic") au lieu de "erreur interne".

## Qualité

| Check | Résultat |
|-------|----------|
| `npm run lint` | ✅ 0 errors |
| `npm run typecheck` | ✅ |
| `npm test` | ✅ 370/370 |
| `npm run build` | ✅ exit 0 |

## Impact

- 1 fichier modifié : `api/_handlers/assistant/chat.js` (+17/-3)
- Aucune nouvelle dépendance
- Aucun changement frontend (le frontend détecte déjà le 503)