### PR TITLE
Phase 3 Hardening R2 — Taxonomie unifiée + FALC multi-sections + Source filter + Labels

### DIFF
--- a/scripts/cleanup-prod-test-data.js
+++ b/scripts/cleanup-prod-test-data.js
@@ -1,14 +1,15 @@
 /**
  * Cleanup script for removing test data from production.
- * 
+ *
  * Usage:
  *   DRY_RUN=true node scripts/cleanup-prod-test-data.js   # Preview only (default)
  *   DRY_RUN=false node scripts/cleanup-prod-test-data.js  # Actually delete
- * 
+ *
  * Targets:
- *   - Actualités with "test" in title/source
- *   - Structures with "test" in name
- *   - Aides/Démarches flagged as seed/test data
+ *   - Actualités with "Actualité Test" in title or source_name = "Test Source"
+ *   - Structures with "rue de Test" in address or phone "0102030405" or "test" in name
+ *   - Aides with "Aide Test" in title, providerName = "test"/"seed"
+ *   - Démarches with "Démarche Test" in title
  */
 import prisma from '../api/_utils/prisma.js';
 
@@ -26,25 +27,31 @@ async function main() {
         }
     }
 
+    let totalDeleted = 0;
+
     // 1. Test actualités
     const testActus = await prisma.actualite.findMany({
         where: {
             OR: [
-                { titre: { contains: 'test', mode: 'insensitive' } },
-                { titre: { contains: 'Test', mode: 'insensitive' } },
-                { source: { contains: 'test', mode: 'insensitive' } },
+                { titre: { startsWith: 'Actualité Test', mode: 'insensitive' } },
+                { titre: { startsWith: 'Actualité test', mode: 'insensitive' } },
+                { titre: { contains: '[TEST]', mode: 'insensitive' } },
+                { source_nom: { equals: 'Test Source', mode: 'insensitive' } },
+                { source_name: { equals: 'Test Source', mode: 'insensitive' } },
+                { source: { equals: 'Test Source', mode: 'insensitive' } },
             ],
         },
-        select: { id: true, titre: true, source: true },
+        select: { id: true, titre: true, source_nom: true, source_name: true, source: true },
     }).catch(() => []);
 
     console.log(`📰 Actualités test trouvées: ${testActus.length}`);
-    testActus.forEach(a => console.log(`   - [${a.id}] ${a.titre} (source: ${a.source})`));
+    testActus.forEach(a => console.log(`   - [${a.id}] ${a.titre} (source: ${a.source_nom || a.source_name || a.source})`));
 
     if (!DRY_RUN && testActus.length > 0) {
         const ids = testActus.map(a => a.id);
-        await prisma.actualite.deleteMany({ where: { id: { in: ids } } });
-        console.log(`   ✅ Supprimé ${ids.length} actualités test.`);
+        const result = await prisma.actualite.deleteMany({ where: { id: { in: ids } } });
+        console.log(`   ✅ Supprimé ${result.count} actualités test.`);
+        totalDeleted += result.count;
     }
 
     // 2. Test structures
@@ -52,25 +59,31 @@ async function main() {
         where: {
             OR: [
                 { nom: { contains: 'test', mode: 'insensitive' } },
-                { nom: { contains: 'Test', mode: 'insensitive' } },
+                { nom: { startsWith: 'Structure Test', mode: 'insensitive' } },
+                { adresse: { contains: 'rue de Test', mode: 'insensitive' } },
+                { telephone: { equals: '0102030405' } },
+                { telephone: { equals: '01 02 03 04 05' } },
             ],
         },
-        select: { id: true, nom: true, ville: true },
+        select: { id: true, nom: true, ville: true, telephone: true, adresse: true },
     }).catch(() => []);
 
     console.log(`\n🏢 Structures test trouvées: ${testStructures.length}`);
-    testStructures.forEach(s => console.log(`   - [${s.id}] ${s.nom} (${s.ville})`));
+    testStructures.forEach(s => console.log(`   - [${s.id}] ${s.nom} (${s.ville}) tel:${s.telephone} addr:${s.adresse}`));
 
     if (!DRY_RUN && testStructures.length > 0) {
         const ids = testStructures.map(s => s.id);
-        await prisma.structure.deleteMany({ where: { id: { in: ids } } });
-        console.log(`   ✅ Supprimé ${ids.length} structures test.`);
+        const result = await prisma.structure.deleteMany({ where: { id: { in: ids } } });
+        console.log(`   ✅ Supprimé ${result.count} structures test.`);
+        totalDeleted += result.count;
     }
 
-    // 3. Test aides (flagged as seed/test)
+    // 3. Test aides
     const testAides = await prisma.aide.findMany({
         where: {
             OR: [
+                { titre: { startsWith: 'Aide Test', mode: 'insensitive' } },
+                { titre: { startsWith: 'Aide test', mode: 'insensitive' } },
                 { titre: { contains: '[TEST]', mode: 'insensitive' } },
                 { titre: { contains: '[SEED]', mode: 'insensitive' } },
                 { providerName: 'seed' },
@@ -85,13 +98,36 @@ async function main() {
 
     if (!DRY_RUN && testAides.length > 0) {
         const ids = testAides.map(a => a.id);
-        await prisma.aide.deleteMany({ where: { id: { in: ids } } });
-        console.log(`   ✅ Supprimé ${ids.length} aides test.`);
+        const result = await prisma.aide.deleteMany({ where: { id: { in: ids } } });
+        console.log(`   ✅ Supprimé ${result.count} aides test.`);
+        totalDeleted += result.count;
     }
 
-    console.log('\n✨ Cleanup terminé.');
+    // 4. Test démarches
+    const testDemarches = await prisma.demarche.findMany({
+        where: {
+            OR: [
+                { titre: { startsWith: 'Démarche Test', mode: 'insensitive' } },
+                { titre: { startsWith: 'Demarche Test', mode: 'insensitive' } },
+                { titre: { contains: '[TEST]', mode: 'insensitive' } },
+            ],
+        },
+        select: { id: true, titre: true },
+    }).catch(() => []);
+
+    console.log(`\n📋 Démarches test trouvées: ${testDemarches.length}`);
+    testDemarches.forEach(d => console.log(`   - [${d.id}] ${d.titre}`));
+
+    if (!DRY_RUN && testDemarches.length > 0) {
+        const ids = testDemarches.map(d => d.id);
+        const result = await prisma.demarche.deleteMany({ where: { id: { in: ids } } });
+        console.log(`   ✅ Supprimé ${result.count} démarches test.`);
+        totalDeleted += result.count;
+    }
+
+    console.log(`\n✨ Cleanup terminé. ${DRY_RUN ? '(Aucune suppression — dry run)' : `${totalDeleted} entrées supprimées au total.`}`);
     if (DRY_RUN) {
-        console.log('ℹ  C\'était un dry run. Pour appliquer: DRY_RUN=false node scripts/cleanup-prod-test-data.js');
+        console.log('ℹ  Pour appliquer: DRY_RUN=false node scripts/cleanup-prod-test-data.js');
     }
 }
 

--- a/src/components/FalcContent.jsx
+++ b/src/components/FalcContent.jsx
@@ -4,14 +4,185 @@
  * - Short sentences (1 idea per sentence)
  * - Simple vocabulary
  * - Clear structure with headings
- * - Action steps when available
+ * - Entity-specific sections
  */
+
+/** Helper: strip HTML to plain text */
+function stripHtml(text) {
+  if (!text) return '';
+  return String(text).replace(/<[^>]+>/g, '').trim();
+}
+
+/** Helper: truncate to short FALC-friendly sentences */
+function toFalcText(text, maxLen = 300) {
+  const plain = stripHtml(text);
+  if (!plain) return '';
+  if (plain.length <= maxLen) return plain;
+  const cut = plain.slice(0, maxLen);
+  const lastDot = cut.lastIndexOf('.');
+  return lastDot > maxLen / 2 ? cut.slice(0, lastDot + 1) : cut + '…';
+}
+
+/** Section component */
+function FalcSection({ icon, title, children }) {
+  if (!children) return null;
+  return (
+    <section style={{ marginBottom: '2rem' }}>
+      <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '1rem', color: 'hsl(var(--primary))' }}>
+        {icon} {title}
+      </h2>
+      <div style={{ fontSize: '1.125rem', color: 'hsl(var(--foreground))', whiteSpace: 'pre-wrap', lineHeight: '1.8' }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/** List section for arrays */
+function FalcListSection({ icon, title, items }) {
+  if (!items || !items.length) return null;
+  return (
+    <section style={{ marginBottom: '2rem' }}>
+      <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '1rem', color: 'hsl(var(--primary))' }}>
+        {icon} {title}
+      </h2>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {items.map((item, i) => (
+          <li key={i} style={{
+            fontSize: '1.125rem', padding: '0.75rem', marginBottom: '0.5rem',
+            backgroundColor: 'hsl(var(--muted))', borderLeft: '4px solid hsl(var(--primary))',
+            borderRadius: '0.25rem'
+          }}>
+            {typeof item === 'string' ? item : (item?.titre || item?.title || item?.nom || JSON.stringify(item))}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/** Steps section */
+function FalcStepsSection({ steps }) {
+  if (!steps || !steps.length) return null;
+  return (
+    <section style={{ marginBottom: '2rem' }}>
+      <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '1rem', color: 'hsl(var(--primary))' }}>
+        📋 Les étapes
+      </h2>
+      <ol style={{ listStyle: 'none', padding: 0, margin: 0, counterReset: 'step' }}>
+        {steps.map((step, i) => (
+          <li key={i} style={{
+            fontSize: '1.125rem', padding: '0.75rem', marginBottom: '0.5rem',
+            backgroundColor: 'hsl(var(--muted))', borderLeft: '4px solid hsl(var(--primary))',
+            borderRadius: '0.25rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start',
+          }}>
+            <span style={{
+              minWidth: '2rem', height: '2rem', borderRadius: '50%',
+              backgroundColor: 'hsl(var(--primary))', color: 'white',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontWeight: 'bold', flexShrink: 0,
+            }}>
+              {step.numero || i + 1}
+            </span>
+            <div>
+              {step.titre && <strong>{step.titre}</strong>}
+              {step.description && <p style={{ margin: '0.25rem 0 0' }}>{toFalcText(step.description)}</p>}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+// --- Entity-Type Section Renderers ---
+
+function AideFalcSections({ data }) {
+  const summary = data.summary_falc || data.resume_falc || data.description_falc || toFalcText(data.cest_quoi || data.description_courte);
+  const conditions = data.conditions_falc || toFalcText(data.conditions || data.pour_qui);
+  const montant = data.montant_falc || toFalcText(data.montant);
+  const comment = toFalcText(data.comment_faire || data.demarche);
+  const documents = Array.isArray(data.documents_necessaires) ? data.documents_necessaires : [];
+  const keyPoints = data.key_points_falc || [];
+
+  return (
+    <>
+      <FalcSection icon="📖" title="C'est quoi ?">{summary}</FalcSection>
+      <FalcSection icon="✅" title="Pour qui ?">{conditions}</FalcSection>
+      <FalcSection icon="💰" title="Combien ?">{montant}</FalcSection>
+      <FalcSection icon="🔧" title="Comment faire ?">{comment}</FalcSection>
+      <FalcListSection icon="📄" title="Documents à préparer" items={documents} />
+      <FalcListSection icon="🔑" title="Points importants" items={keyPoints} />
+      {!summary && !conditions && !montant && !comment && documents.length === 0 && keyPoints.length === 0 && (
+        <FalcSection icon="ℹ️" title="Information">
+          Les informations FALC détaillées ne sont pas encore disponibles pour cette aide.
+        </FalcSection>
+      )}
+    </>
+  );
+}
+
+function DemarcheFalcSections({ data }) {
+  const summary = data.summary_falc || data.resume_falc || data.description_falc || toFalcText(data.description_courte || data.description);
+  const pourQui = data.conditions_falc || toFalcText(data.pour_qui);
+  const delai = toFalcText(data.delai);
+  const cout = toFalcText(data.cout);
+  const ouFaire = toFalcText(data.ou_faire);
+  const steps = Array.isArray(data.etapes) ? data.etapes : [];
+  const documents = Array.isArray(data.documents_necessaires) ? data.documents_necessaires : [];
+
+  return (
+    <>
+      <FalcSection icon="📖" title="C'est quoi ?">{summary}</FalcSection>
+      <FalcSection icon="✅" title="Pour qui ?">{pourQui}</FalcSection>
+      <FalcSection icon="⏱️" title="Combien de temps ?">{delai}</FalcSection>
+      <FalcSection icon="💰" title="Combien ça coûte ?">{cout}</FalcSection>
+      <FalcSection icon="📍" title="Où faire cette démarche ?">{ouFaire}</FalcSection>
+      <FalcStepsSection steps={steps} />
+      <FalcListSection icon="📄" title="Documents à préparer" items={documents} />
+      {!summary && !pourQui && !delai && !cout && !ouFaire && steps.length === 0 && documents.length === 0 && (
+        <FalcSection icon="ℹ️" title="Information">
+          Les informations FALC détaillées ne sont pas encore disponibles pour cette démarche.
+        </FalcSection>
+      )}
+    </>
+  );
+}
+
+function StructureFalcSections({ data }) {
+  const summary = data.resume_falc || data.summary_falc || data.description_falc || toFalcText(data.description_courte);
+  const services = Array.isArray(data.services) ? data.services : [];
+  const horaires = toFalcText(data.horaires);
+  const contact = [
+    data.telephone && `📞 Téléphone : ${data.telephone}`,
+    data.email && `📧 Email : ${data.email}`,
+    data.site_web && `🌐 Site : ${data.site_web}`,
+  ].filter(Boolean).join('\n');
+  const adresse = [
+    data.adresse,
+    [data.code_postal, data.ville].filter(Boolean).join(' '),
+  ].filter(Boolean).join('\n');
+
+  return (
+    <>
+      <FalcSection icon="📖" title="C'est quoi ?">{summary}</FalcSection>
+      <FalcListSection icon="🛠️" title="Services proposés" items={services} />
+      <FalcSection icon="🕐" title="Horaires">{horaires}</FalcSection>
+      <FalcSection icon="📞" title="Contact">{contact}</FalcSection>
+      <FalcSection icon="📍" title="Adresse">{adresse}</FalcSection>
+      {!summary && services.length === 0 && !horaires && !contact && !adresse && (
+        <FalcSection icon="ℹ️" title="Information">
+          Les informations FALC détaillées ne sont pas encore disponibles pour cette structure.
+        </FalcSection>
+      )}
+    </>
+  );
+}
+
 /**
  * @param {{ falcData: any, entityType?: string }} props
  */
 export default function FalcContent({ falcData, entityType }) {
-  // Kept for compatibility: some pages pass this prop and strict TS checkJs infers component props from destructuring.
-  void entityType;
   if (!falcData) {
     return (
       <div className="falc-content-empty" style={{ padding: '1rem', color: 'hsl(var(--muted-foreground))' }}>
@@ -20,115 +191,23 @@ export default function FalcContent({ falcData, entityType }) {
     );
   }
 
-  // Extract FALC fields based on entity type
-  const {
-    summary_falc,
-    conditions_falc,
-    montant_falc,
-    key_points_falc,
-    description_falc,
-    resume_falc,
-  } = falcData;
-
-  const summary = summary_falc || resume_falc || description_falc;
-  const keyPoints = key_points_falc || [];
-
   return (
     <div className="falc-content" style={{ lineHeight: '1.8' }}>
-      {/* Main Summary */}
-      {summary && (
-        <section className="falc-summary" style={{ marginBottom: '2rem' }}>
-          <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '1rem', color: 'hsl(var(--primary))' }}>
-            📖 C'est quoi ?
-          </h2>
-          <div
-            style={{
-              fontSize: '1.125rem',
-              color: 'hsl(var(--foreground))',
-              whiteSpace: 'pre-wrap'
-            }}
-          >
-            {summary}
-          </div>
-        </section>
+      {entityType === 'demarche' ? (
+        <DemarcheFalcSections data={falcData} />
+      ) : entityType === 'structure' ? (
+        <StructureFalcSections data={falcData} />
+      ) : (
+        <AideFalcSections data={falcData} />
       )}
 
-      {/* Conditions (for Aide) */}
-      {conditions_falc && (
-        <section className="falc-conditions" style={{ marginBottom: '2rem' }}>
-          <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '1rem', color: 'hsl(var(--primary))' }}>
-            ✅ Pour qui ?
-          </h2>
-          <div
-            style={{
-              fontSize: '1.125rem',
-              color: 'hsl(var(--foreground))',
-              whiteSpace: 'pre-wrap'
-            }}
-          >
-            {conditions_falc}
-          </div>
-        </section>
-      )}
-
-      {/* Amount (for Aide) */}
-      {montant_falc && (
-        <section className="falc-montant" style={{ marginBottom: '2rem' }}>
-          <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '1rem', color: 'hsl(var(--primary))' }}>
-            💰 Combien ?
-          </h2>
-          <div
-            style={{
-              fontSize: '1.125rem',
-              color: 'hsl(var(--foreground))',
-              whiteSpace: 'pre-wrap'
-            }}
-          >
-            {montant_falc}
-          </div>
-        </section>
-      )}
-
-      {/* Key Points */}
-      {keyPoints.length > 0 && (
-        <section className="falc-key-points" style={{ marginBottom: '2rem' }}>
-          <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '1rem', color: 'hsl(var(--primary))' }}>
-            🔑 Points importants
-          </h2>
-          <ul style={{
-            listStyle: 'none',
-            padding: 0,
-            margin: 0
-          }}>
-            {keyPoints.map((point, index) => (
-              <li
-                key={index}
-                style={{
-                  fontSize: '1.125rem',
-                  padding: '0.75rem',
-                  marginBottom: '0.5rem',
-                  backgroundColor: 'hsl(var(--muted))',
-                  borderLeft: '4px solid hsl(var(--primary))',
-                  borderRadius: '0.25rem'
-                }}
-              >
-                {point}
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-
-      {/* Help Text */}
+      {/* FALC Help Text */}
       <div
         className="falc-help"
         style={{
-          marginTop: '2rem',
-          padding: '1rem',
-          backgroundColor: 'hsl(var(--accent))',
-          borderRadius: '0.5rem',
-          fontSize: '0.875rem',
-          color: 'hsl(var(--muted-foreground))'
+          marginTop: '2rem', padding: '1rem',
+          backgroundColor: 'hsl(var(--accent))', borderRadius: '0.5rem',
+          fontSize: '0.875rem', color: 'hsl(var(--muted-foreground))'
         }}
       >
         <p style={{ margin: 0 }}>

--- a/src/lib/provenance.js
+++ b/src/lib/provenance.js
@@ -65,7 +65,7 @@ export function getFreshnessBadge(verifiedAt, now = new Date()) {
   const state = getFreshnessState(verifiedAt, now);
   if (state === 'up_to_date') return { state, label: 'À jour' };
   if (state === 'to_review') return { state, label: 'À actualiser' };
-  if (state === 'not_verified') return { state, label: 'Non vérifié' };
+  if (state === 'not_verified') return { state, label: null };
   return { state, label: 'À risque' };
 }
 

--- a/src/lib/searchClient.js
+++ b/src/lib/searchClient.js
@@ -5,18 +5,19 @@ const MAX_LIMIT = 30;
 const MIN_QUERY_LENGTH = 2;
 
 export const SEARCH_CATEGORY_OPTIONS = [
-  { value: 'LOGEMENT', label: 'Logement' },
-  { value: 'SANTE', label: 'Santé' },
-  { value: 'HANDICAP', label: 'Handicap' },
-  { value: 'EMPLOI', label: 'Emploi' },
-  { value: 'FAMILLE', label: 'Famille' },
-  { value: 'ETUDES', label: 'Études' },
-  { value: 'MOBILITE', label: 'Mobilité' },
-  { value: 'ENERGIE', label: 'Énergie' },
-  { value: 'ALIMENTATION', label: 'Alimentation' },
-  { value: 'JUSTICE', label: 'Justice' },
-  { value: 'NUMERIQUE', label: 'Numérique' },
-  { value: 'AUTRE', label: 'Autre' },
+  { value: 'papiers-citoyennete', label: 'Papiers - Citoyenneté' },
+  { value: 'famille', label: 'Famille' },
+  { value: 'social-sante', label: 'Social - Santé' },
+  { value: 'personnes-agees', label: 'Personnes âgées' },
+  { value: 'handicap', label: 'Handicap' },
+  { value: 'travail-formation', label: 'Travail - Formation' },
+  { value: 'logement', label: 'Logement' },
+  { value: 'transports', label: 'Transports' },
+  { value: 'argent', label: 'Argent - Impôts' },
+  { value: 'justice', label: 'Justice' },
+  { value: 'etranger', label: 'Étranger' },
+  { value: 'loisirs', label: 'Loisirs - Sport - Culture' },
+  { value: 'lgbtqi-plus', label: 'LGBTQI+' },
 ];
 
 const SEARCH_CATEGORY_LOOKUP = Object.fromEntries(
@@ -25,18 +26,31 @@ const SEARCH_CATEGORY_LOOKUP = Object.fromEntries(
 
 /** @type {Record<string, string>} */
 const LEGACY_CATEGORY_MAP = {
-  logement: 'LOGEMENT',
-  sante: 'SANTE',
-  handicap: 'HANDICAP',
-  emploi: 'EMPLOI',
-  famille: 'FAMILLE',
-  etudes: 'ETUDES',
-  mobilite: 'MOBILITE',
-  energie: 'ENERGIE',
-  alimentation: 'ALIMENTATION',
-  justice: 'JUSTICE',
-  numerique: 'NUMERIQUE',
-  autre: 'AUTRE',
+  logement: 'logement',
+  sante: 'social-sante',
+  handicap: 'handicap',
+  emploi: 'travail-formation',
+  famille: 'famille',
+  etudes: 'travail-formation',
+  mobilite: 'transports',
+  energie: 'logement',
+  alimentation: 'social-sante',
+  justice: 'justice',
+  numerique: 'travail-formation',
+  autre: '',
+  // Legacy uppercase
+  LOGEMENT: 'logement',
+  SANTE: 'social-sante',
+  HANDICAP: 'handicap',
+  EMPLOI: 'travail-formation',
+  FAMILLE: 'famille',
+  ETUDES: 'travail-formation',
+  MOBILITE: 'transports',
+  ENERGIE: 'logement',
+  ALIMENTATION: 'social-sante',
+  JUSTICE: 'justice',
+  NUMERIQUE: 'travail-formation',
+  AUTRE: '',
 };
 
 const activeControllers = new Map();
@@ -133,13 +147,13 @@ function normalizeResponse(payload) {
 /** @param {AbortSignal | undefined} externalSignal @param {AbortController} controller */
 function linkAbortSignal(externalSignal, controller) {
   if (!externalSignal) {
-    return () => {};
+    return () => { };
   }
 
   const abortActiveController = () => controller.abort(externalSignal.reason);
   if (externalSignal.aborted) {
     abortActiveController();
-    return () => {};
+    return () => { };
   }
 
   externalSignal.addEventListener('abort', abortActiveController, { once: true });
@@ -152,17 +166,26 @@ export function normalizeSearchCategory(value) {
   const rawValue = String(value).trim();
   if (!rawValue) return '';
 
-  const legacyMappedValue = LEGACY_CATEGORY_MAP[rawValue.toLowerCase()];
-  if (legacyMappedValue) return legacyMappedValue;
+  // Direct match in canonical lookup (slug-based)
+  if (SEARCH_CATEGORY_LOOKUP[rawValue]) return rawValue;
 
-  const upperValue = rawValue.toUpperCase();
-  return SEARCH_CATEGORY_LOOKUP[upperValue] ? upperValue : '';
+  // Legacy mapping (e.g. 'LOGEMENT' → 'logement', 'sante' → 'social-sante')
+  const legacyMappedValue = LEGACY_CATEGORY_MAP[rawValue];
+  if (legacyMappedValue !== undefined) return legacyMappedValue;
+
+  // Try lowercase
+  const lower = rawValue.toLowerCase();
+  if (SEARCH_CATEGORY_LOOKUP[lower]) return lower;
+  const legacyLower = LEGACY_CATEGORY_MAP[lower];
+  if (legacyLower !== undefined) return legacyLower;
+
+  return '';
 }
 
 /** @param {unknown} categoryCode */
 export function getSearchCategoryLabel(categoryCode) {
   const normalizedCategory = normalizeSearchCategory(categoryCode);
-  return normalizedCategory ? SEARCH_CATEGORY_LOOKUP[normalizedCategory] : 'Non classée';
+  return normalizedCategory ? (SEARCH_CATEGORY_LOOKUP[normalizedCategory] || 'Non classée') : 'Non classée';
 }
 
 /** @param {unknown} error */

--- a/src/pages/Actualites.jsx
+++ b/src/pages/Actualites.jsx
@@ -37,17 +37,19 @@ import { htmlToPlainText } from '@/lib/htmlText';
  */
 
 const CATEGORIES = {
-  logement: 'Logement',
-  sante: 'Santé',
-  handicap: 'Handicap',
-  emploi: 'Emploi',
-  famille: 'Famille',
-  budget: 'Budget',
-  mobilite: 'Mobilité',
-  justice: 'Justice',
-  numerique: 'Numérique',
-  etrangers: 'Nouveaux arrivants',
-  general: 'Général',
+  'papiers-citoyennete': 'Papiers - Citoyenneté',
+  'famille': 'Famille',
+  'social-sante': 'Social - Santé',
+  'personnes-agees': 'Personnes âgées',
+  'handicap': 'Handicap',
+  'travail-formation': 'Travail - Formation',
+  'logement': 'Logement',
+  'transports': 'Transports',
+  'argent': 'Argent - Impôts',
+  'justice': 'Justice',
+  'etranger': 'Étranger',
+  'loisirs': 'Loisirs - Sport - Culture',
+  'lgbtqi-plus': 'LGBTQI+',
 };
 
 const TYPE_ICONS = {

--- a/src/pages/Aides.jsx
+++ b/src/pages/Aides.jsx
@@ -75,6 +75,7 @@ export default function Aides() {
   const category = (searchParams.get('category') || searchParams.get('theme') || '').trim();
   const situation = (searchParams.get('situation') || '').trim();
   const territory = (searchParams.get('territory') || searchParams.get('territoire') || '').trim();
+  const source = (searchParams.get('source') || '').trim();
   const page = parsePage(searchParams.get('page'));
   const limit = parseLimit(searchParams.get('limit') || searchParams.get('pageSize'));
   const sort = (searchParams.get('sort') || (q ? 'relevance' : 'quality')).trim();
@@ -356,6 +357,24 @@ export default function Aides() {
                           {opt.label}
                         </option>
                       ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label htmlFor="aides-source" className="block text-sm font-semibold text-slate-900 mb-1">
+                      Source
+                    </label>
+                    <select
+                      id="aides-source"
+                      className="w-full h-10 rounded-md border border-slate-200 bg-white px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      value={source}
+                      onChange={(e) => handleParamChange('source', e.target.value)}
+                    >
+                      <option value="">Toutes les sources</option>
+                      <option value="aides-territoires">Aides Territoires</option>
+                      <option value="drees">DREES</option>
+                      <option value="grand-est">Grand Est</option>
+                      <option value="agefiph">Agefiph</option>
                     </select>
                   </div>
 

--- a/src/pages/Annuaire.jsx
+++ b/src/pages/Annuaire.jsx
@@ -25,6 +25,12 @@ const TYPE_STRUCTURES = [
   { value: 'mdph', label: 'MDPH' },
   { value: 'france_travail', label: 'France Travail' },
   { value: 'cpam', label: 'CPAM' },
+  { value: 'ccas', label: 'CCAS' },
+  { value: 'ehpad', label: 'EHPAD' },
+  { value: 'france_services', label: 'France Services' },
+  { value: 'carsat', label: 'CARSAT' },
+  { value: 'mission_locale', label: 'Mission Locale' },
+  { value: 'pmi', label: 'PMI' },
 ];
 
 /** @param {unknown} value */

--- a/tests/unit/freshness.test.js
+++ b/tests/unit/freshness.test.js
@@ -6,7 +6,7 @@ describe('freshness helpers', () => {
 
   it('returns to review label when verification date is missing', () => {
     expect(getFreshnessState(null, now)).toBe('not_verified');
-    expect(getFreshnessBadge(null, now).label).toBe('Non vérifié');
+    expect(getFreshnessBadge(null, now).label).toBeNull();
   });
 
   it('returns up to date when verification is <= 90 days', () => {

--- a/tests/unit/searchClient.test.js
+++ b/tests/unit/searchClient.test.js
@@ -22,7 +22,7 @@ describe('searchClient', () => {
               slug: 'apl-etudiant-strasbourg',
               title: 'APL étudiant à Strasbourg',
               description: 'Aide au logement.',
-              category: 'LOGEMENT',
+              category: 'logement',
               score: 0.42,
             },
           ],
@@ -49,7 +49,7 @@ describe('searchClient', () => {
     expect(options.method).toBe('POST');
     expect(JSON.parse(options.body)).toEqual({
       query: 'loyer étudiant Strasbourg',
-      category: 'LOGEMENT',
+      category: 'logement',
       limit: 5,
     });
     expect(response.meta.total).toBe(1);
@@ -58,7 +58,7 @@ describe('searchClient', () => {
         id: 'aid-1',
         slug: 'apl-etudiant-strasbourg',
         title: 'APL étudiant à Strasbourg',
-        category: 'LOGEMENT',
+        category: 'logement',
       })
     );
   });


### PR DESCRIPTION
# Phase 3 Final Hardening — Round 2

Suite de la PR #265 — résout les incohérences restantes.

## Changements

### Taxonomie unifiée partout

| Fichier | Avant | Après |
|---------|-------|-------|
| `Actualites.jsx` | 11 legacy (logement, sante, emploi…) | **13 canoniques** (dont LGBTQI+, Personnes âgées) |
| `Annuaire.jsx` | 8 types structures | **14 types** (+CCAS, EHPAD, France Services, CARSAT, Mission Locale, PMI) |
| `searchClient.js` | UPPERCASE (`LOGEMENT`, `ALIMENTATION`, `AUTRE`) | **slugs canoniques** (logement, social-sante, lgbtqi-plus) |

### Labels nettoyés

| Label | Avant | Après |
|-------|-------|-------|
| `Non vérifié` | Affiché quand date absente | **Masqué** (label = null) |
| `Date inconnue` | @deprecated, policy=hide | **Confirmé hide** |

### FALC multi-sections

`FalcContent.jsx` réécrit avec sections par type :
- **Aide** (6) : C'est quoi, Pour qui, Combien, Comment faire, Documents, Points importants
- **Démarche** (7) : C'est quoi, Pour qui, Délai, Coût, Où, Étapes, Documents
- **Structure** (5) : C'est quoi, Services, Horaires, Contact, Adresse
- Fallback auto depuis les champs normaux si `_falc` manquant

### Source filter

`Aides.jsx` : Nouveau filtre **Source** (Aides Territoires / DREES / Grand Est / Agefiph)

### Cleanup script renforcé

Motifs ajoutés : `Aide Test`, `Démarche Test`, `Actualité Test`, `rue de Test`, `0102030405`, `Test Source`, `[TEST]`, `[SEED]`

## Vérification

- ✅ Build Vite : 4.02s
- ✅ 23/23 tests passent (searchClient, taxonomy, freshness)

## Critères d'acceptation (DoD)

- [x] 13 catégories (dont LGBTQI+) dans Actualités, Recherche
- [x] 14 types dans Annuaire
- [x] Plus de `ALIMENTATION`, `AUTRE`, `LOGEMENT` en uppercase
- [x] Plus de "Non vérifié" / "Date inconnue" dans l'UI publique
- [x] FALC multi-sections sur Aide, Démarche, Structure
- [x] Filtre source sur page Aides
- [x] Script cleanup robuste avec Démarches