### PR TITLE
Fix: Remove standalone api/aids.js + api/drees.js (Vercel routing conflict)

### DIFF
--- a/api/aids.js
+++ b/api/aids.js
@@ -1,2 +1,0 @@
-
-export { default } from './_handlers/aides.js';

--- a/api/drees.js
+++ b/api/drees.js
@@ -1,2 +1,0 @@
-
-export { default } from './_handlers/drees.js';


### PR DESCRIPTION
# Fix: Remove standalone api/aids.js + api/drees.js (Vercel routing conflict)

## 🔍 Root Cause (actual)

**Vercel file-based routing takes precedence over rewrites.**

The `vercel.json` rewrite rule:
```json
{ "source": "/api/(.*)", "destination": "/api" }
```
was supposed to route ALL `/api/*` traffic through `api/index.js`. But Vercel matched `api/drees.js` as a **standalone serverless function FIRST**, creating a separate function context that bypassed:

- ❌ The unified router (`routes.js`)
- ❌ The boot guard and error handling
- ❌ Sentry integration
- ❌ CORS headers
- ❌ Rate limiting
- ❌ Request logging

The standalone `api/drees.js` function created its own isolated context without proper Prisma initialization, causing `FUNCTION_INVOCATION_FAILED`.

## ✅ Fix

**Delete the standalone files.** The routing for `/api/aids` and `/api/drees` is already handled by `routes.js` (lines 151-153) through `api/index.js`:

```javascript
{ path: 'aides', match: 'prefix', handler: aides },
{ path: 'aids', match: 'prefix', handler: aides },
{ path: 'drees', match: 'prefix', handler: drees },
```

## 📋 Files Changed

| File | Change |
|------|--------|
| `api/aids.js` | **DELETED** |
| `api/drees.js` | **DELETED** |

## ✅ Validation

```bash
curl -s "https://www.accesdirectaide.fr/api/drees?page=1&limit=1" | jq .pagination
curl -s "https://www.accesdirectaide.fr/api/aids?page=1&limit=1" | jq .pagination
```

Expected: HTTP 200 with `{ items, pagination }` JSON.