### PR TITLE
Fix /api/drees 500 — add DREES_API to rateLimit actions

### DIFF
--- a/api/_utils/rateLimit.js
+++ b/api/_utils/rateLimit.js
@@ -55,6 +55,7 @@ const CONFIG = {
     SEARCH_AIDES: { limit: 30, window: 60 },      // 30 per min
     SEARCH_STRUCTURES: { limit: 30, window: 60 }, // 30 per min
     SEARCH_RESSOURCES: { limit: 60, window: 60 }, // 60 per min
+    DREES_API: { limit: 30, window: 60 },         // 30 per min
     TAXONOMY: { limit: 60, window: 60 },          // 60 per min
     // Assistant (AI)
     ASSISTANT_CHAT: { limit: 10, window: 60 },    // 10 per min
@@ -161,9 +162,15 @@ function getErrorObject() {
     };
 }
 
+// Default fallback config for unknown actions — never crash
+const DEFAULT_RATE_LIMIT = { limit: 30, window: 60 };
+
 export async function checkRateLimit(action, identifier) {
-    const config = CONFIG[action];
-    if (!config) throw new Error(`Unknown action: ${action}`);
+    let config = CONFIG[action];
+    if (!config) {
+        console.warn(`[RateLimit] Unknown action "${action}" — using default (${DEFAULT_RATE_LIMIT.limit}/${DEFAULT_RATE_LIMIT.window}s)`);
+        config = DEFAULT_RATE_LIMIT;
+    }
 
     if (hasHttpKv) {
         return checkRateLimitKV(action, identifier);


### PR DESCRIPTION
# Fix /api/drees 500 — add DREES_API to rateLimit actions

## 🔍 Root Cause (Vercel Runtime Logs)

```
Error: Unknown action: DREES_APIat checkRateLimit (api/_utils/rateLimit.js:166)at Object.handler (api/_handlers/drees.js:15)
```

The `DREES_API` action used in `_handlers/drees.js:15` was **not registered** in the `CONFIG` map of `rateLimit.js`. The `checkRateLimit` function threw a fatal `Error` on unknown actions, crashing the handler before any Prisma query.

## ✅ Fix

### 1. Add `DREES_API` to CONFIG

```diff
 SEARCH_RESSOURCES: { limit: 60, window: 60 },
+DREES_API: { limit: 30, window: 60 },         // 30 per min
 TAXONOMY: { limit: 60, window: 60 },
```

### 2. Harden `checkRateLimit` — never throw on unknown action

```diff
+const DEFAULT_RATE_LIMIT = { limit: 30, window: 60 };
+
 export async function checkRateLimit(action, identifier) {
-    const config = CONFIG[action];
-    if (!config) throw new Error(`Unknown action: ${action}`);
+    let config = CONFIG[action];
+    if (!config) {
+        console.warn(`[RateLimit] Unknown action "${action}" — using default`);
+        config = DEFAULT_RATE_LIMIT;
+    }
```

## 📋 File

| File | Change |
|------|--------|
| `api/_utils/rateLimit.js` | +9 −2: add DREES_API + graceful fallback on unknown actions |

## ✅ Verification

- ✅ Build: 3.97s
- ✅ 5/5 tests pass (`api-aids-drees.test.js`)

## 🧪 Post-merge validation

```bash
curl -s "https://www.accesdirectaide.fr/api/drees?page=1&limit=1" | jq .pagination
curl -s "https://www.accesdirectaide.fr/api/aids?page=1&limit=1" | jq .pagination
```