### PR TITLE
feat(security): Phase 2 PR1 — RBAC enforcement + SIAO feature flag

### DIFF
--- a/api/_handlers/pro/agent-discovery.js
+++ b/api/_handlers/pro/agent-discovery.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
-import { requireAuth } from '../../lib/pro-auth.js';
+import { requireProAuth } from '../../_utils/auth.js';
 import prisma from '../../_utils/prisma.js';
+import logger from '../../_utils/logger.js';
 
 /**
  * Agent Discovery API (Pro-only)
@@ -59,7 +60,7 @@ async function handler(req, res) {
 
         if (!response.ok) {
             const errText = await response.text();
-            console.error('[Discovery] Gemini error:', errText);
+            logger.error({ status: response.status, body: errText?.slice(0, 200) }, '[Discovery] Gemini error');
             return res.status(502).json({ error: 'Erreur IA lors du scan.' });
         }
 
@@ -101,7 +102,7 @@ async function handler(req, res) {
                     });
                     submitted++;
                 } catch (dbErr) {
-                    console.error('[Discovery] ReviewQueueItem creation failed:', dbErr.message);
+                    logger.warn({ err: dbErr }, '[Discovery] ReviewQueueItem creation failed');
                 }
             }
         }
@@ -115,10 +116,9 @@ async function handler(req, res) {
             scannedAt: new Date().toISOString(),
         });
     } catch (error) {
-        console.error('[Discovery] Erreur:', error.message);
+        logger.error({ err: error }, '[Discovery] Erreur');
         return res.status(500).json({ error: 'Échec du scan autonome.' });
     }
 }
 
-export default requireAuth(handler);
-
+export default requireProAuth(handler);

--- a/api/_handlers/pro/agent-scheduler.js
+++ b/api/_handlers/pro/agent-scheduler.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
-import { verifyProToken } from '../../lib/pro-auth.js';
+import { requireProAuth } from '../../_utils/auth.js';
+import logger from '../../_utils/logger.js';
 
 /**
  * Agent Scheduler API (Pro-only)
@@ -18,15 +19,10 @@ import { verifyProToken } from '../../lib/pro-auth.js';
 const GEMINI_URL =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'POST') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
-
-    const token = req.cookies?.pro_token;
-    if (!token) return res.status(401).json({ error: 'Non autorisé.' });
-    const user = verifyProToken(token);
-    if (!user) return res.status(401).json({ error: 'Session invalide.' });
 
     const { poleId, categoryId } = req.body || {};
     if (!poleId) {
@@ -87,7 +83,7 @@ export default async function handler(req, res) {
                             summary: item.summary || '',
                             category,
                             confidence: item.confidence,
-                            scheduledBy: user.sub || user.id || 'system',
+                            scheduledBy: req.user?.userId || 'system',
                         },
                     },
                 });
@@ -126,7 +122,9 @@ export default async function handler(req, res) {
             nextSchedule: 'Prochain cycle automatique',
         });
     } catch (error) {
-        console.error('[Scheduler]', error.message);
+        logger.error({ err: error }, '[Scheduler] Erreur');
         return res.status(500).json({ error: "Échec de l'orchestration." });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/attestation-data.js
+++ b/api/_handlers/pro/attestation-data.js
@@ -1,7 +1,8 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
-import { verifyProToken } from '../../lib/pro-auth.js';
+import { requireProAuth, requireProStructureContext } from '../../_utils/auth.js';
 import crypto from 'crypto';
+import logger from '../../_utils/logger.js';
 
 /**
  * Attestation Data API (Pro-only)
@@ -11,16 +12,13 @@ import crypto from 'crypto';
  * Prepares certified data for the official attestation PDF.
  * Generates a SHA-256 certification hash for tamper-proof verification.
  */
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'GET') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
 
-    // Auth
-    const token = req.cookies?.pro_token;
-    if (!token) return res.status(401).json({ error: 'Non autorisé.' });
-    const user = verifyProToken(token);
-    if (!user) return res.status(401).json({ error: 'Session invalide.' });
+    const proCtx = requireProStructureContext(req, res);
+    if (!proCtx) return;
 
     const url = new URL(req.url || '/', `https://${req.headers?.host || 'localhost'}`);
     const shareId = url.searchParams.get('shareId');
@@ -53,10 +51,9 @@ export default async function handler(req, res) {
         delete results._files;
         delete results._consent;
 
-        // Agent info from auth token
-        const proName = user.firstName
-            ? `${user.firstName} ${(user.lastName || '')[0]}.`
-            : 'Agent ADA';
+        // Agent info from auth context
+        const user = req.user || {};
+        const proName = user.email ? user.email.split('@')[0] : 'Agent ADA';
 
         return res.status(200).json({
             ok: true,
@@ -70,14 +67,16 @@ export default async function handler(req, res) {
                 professional: {
                     name: proName,
                     role: user.role || 'Agent',
-                    structure: user.structureName || 'AccesDirectAide',
+                    structure: proCtx.structureId,
                 },
                 certHash,
                 verifyUrl: `https://accesdirectaide.fr/verify/${reference}`,
             },
         });
     } catch (error) {
-        console.error('[Attestation] Erreur:', error.message);
+        logger.error({ err: error }, '[Attestation] Erreur');
         return res.status(500).json({ error: 'Erreur attestation.' });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/consent.js
+++ b/api/_handlers/pro/consent.js
@@ -1,10 +1,12 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
+import { requireProAuth } from '../../_utils/auth.js';
 import { logProAudit } from '../../lib/pro-auth.js';
 import crypto from 'crypto';
+import logger from '../../_utils/logger.js';
 
 /**
- * Consent API
+ * Consent API (Pro-authenticated)
  *
  * POST /api/pro/consent
  *
@@ -16,7 +18,7 @@ import crypto from 'crypto';
  * - shareId: SharedDiagnostic ID
  * - signatureData: base64 canvas data URL
  */
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'POST') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
@@ -88,7 +90,9 @@ export default async function handler(req, res) {
             signatureHash,
         });
     } catch (error) {
-        console.error('[Consent] Erreur:', error.message);
+        logger.error({ err: error }, '[Consent] Erreur');
         return res.status(500).json({ error: 'Échec de l\'enregistrement du consentement.' });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/dossier-synthesis.js
+++ b/api/_handlers/pro/dossier-synthesis.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
-import { verifyProToken } from '../../lib/pro-auth.js';
+import { requireProAuth, requireProStructureContext } from '../../_utils/auth.js';
+import logger from '../../_utils/logger.js';
 
 /**
  * Dossier AI Synthesis API (Pro-only)
@@ -23,20 +24,13 @@ Chaque point doit être une phrase courte, factuelle et actionnable pour le bén
 Format ta réponse UNIQUEMENT comme un tableau JSON de 3 chaînes de caractères.
 Exemple: ["Point 1", "Point 2", "Point 3"]`;
 
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'POST') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
 
-    // Auth: only pro users
-    const token = req.cookies?.pro_token;
-    if (!token) {
-        return res.status(401).json({ error: 'Non autorisé.' });
-    }
-    const user = verifyProToken(token);
-    if (!user) {
-        return res.status(401).json({ error: 'Session invalide.' });
-    }
+    const proCtx = requireProStructureContext(req, res);
+    if (!proCtx) return;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
     if (!apiKey) {
@@ -83,7 +77,7 @@ export default async function handler(req, res) {
 
         if (!response.ok) {
             const errText = await response.text().catch(() => '');
-            console.error('[Synthesis] Gemini error:', response.status, errText.slice(0, 200));
+            logger.error({ status: response.status, body: errText.slice(0, 200) }, '[Synthesis] Gemini error');
             return res.status(502).json({ error: 'Erreur du service IA.' });
         }
 
@@ -109,7 +103,9 @@ export default async function handler(req, res) {
 
         return res.status(200).json({ ok: true, points });
     } catch (error) {
-        console.error('[Synthesis] Erreur:', error.message);
+        logger.error({ err: error }, '[Synthesis] Erreur');
         return res.status(500).json({ error: 'Échec de la synthèse IA.' });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/dossier/upload-secure.js
+++ b/api/_handlers/pro/dossier/upload-secure.js
@@ -1,9 +1,11 @@
 // @ts-nocheck
 import prisma from '../../../_utils/prisma.js';
+import { requireProAuth, requireProStructureContext } from '../../../_utils/auth.js';
 import { logProAudit } from '../../../lib/pro-auth.js';
+import logger from '../../../_utils/logger.js';
 
 /**
- * Secure File Upload Handler
+ * Secure File Upload Handler (Pro-only)
  *
  * POST /api/pro/dossier/upload-secure
  *
@@ -17,10 +19,13 @@ import { logProAudit } from '../../../lib/pro-auth.js';
  * - originalName: original filename
  * - mimeType: original MIME type
  */
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'POST') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
+
+    const proCtx = requireProStructureContext(req, res);
+    if (!proCtx) return;
 
     try {
         const { shareId, originalName, mimeType } = req.body || {};
@@ -69,7 +74,7 @@ export default async function handler(req, res) {
 
         // Audit log
         const ip = req.headers?.['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
-        await logProAudit('FILE_UPLOADED', 'citizen', '', {
+        await logProAudit('FILE_UPLOADED', proCtx.userId, proCtx.structureId, {
             shareId,
             fileName: originalName,
             encrypted: true,
@@ -81,7 +86,9 @@ export default async function handler(req, res) {
             message: 'Fichier chiffré reçu et enregistré.',
         });
     } catch (error) {
-        console.error('[Upload Secure] Erreur:', error.message);
+        logger.error({ err: error }, '[Upload Secure] Erreur');
         return res.status(500).json({ error: 'Erreur lors de l\'envoi.' });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/health-check.js
+++ b/api/_handlers/pro/health-check.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
-import { verifyProToken } from '../../lib/pro-auth.js';
+import { requireProAuth } from '../../_utils/auth.js';
+import logger from '../../_utils/logger.js';
 
 /**
  * Health Check API (Pro-only)
@@ -13,15 +14,10 @@ import { verifyProToken } from '../../lib/pro-auth.js';
  *   - Pending moderation count
  *   - Environment info
  */
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'GET') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
-
-    const token = req.cookies?.pro_token;
-    if (!token) return res.status(401).json({ error: 'Non autorisé.' });
-    const user = verifyProToken(token);
-    if (!user) return res.status(401).json({ error: 'Session invalide.' });
 
     try {
         // 1. Database ping latency
@@ -55,6 +51,7 @@ export default async function handler(req, res) {
         });
 
         // 6. Service status inference
+        const siaEnabled = process.env.SIAO_ENABLED === 'true';
         const services = [
             {
                 id: 'db',
@@ -79,7 +76,7 @@ export default async function handler(req, res) {
                 id: 'siao',
                 label: 'Passerelle SIAO',
                 sub: 'Interop National',
-                status: process.env.SIAO_API_URL ? 'operational' : 'not_configured',
+                status: siaEnabled && process.env.SIAO_API_URL ? 'operational' : 'not_configured',
             },
         ];
 
@@ -102,7 +99,7 @@ export default async function handler(req, res) {
             timestamp: new Date().toISOString(),
         });
     } catch (error) {
-        console.error('[HealthCheck] Error:', error.message);
+        logger.error({ err: error }, '[HealthCheck] Error');
         return res.status(500).json({
             status: 'DEGRADED',
             error: error.message,
@@ -110,3 +107,5 @@ export default async function handler(req, res) {
         });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/interop-siao.js
+++ b/api/_handlers/pro/interop-siao.js
@@ -1,7 +1,7 @@
-import logger from '../../_utils/logger.js';
 // @ts-nocheck
+import logger from '../../_utils/logger.js';
 import prisma from '../../_utils/prisma.js';
-import { verifyProToken } from '../../lib/pro-auth.js';
+import { requireProAuth, requireProStructureContext } from '../../_utils/auth.js';
 import crypto from 'crypto';
 
 /**
@@ -12,18 +12,27 @@ import crypto from 'crypto';
  *
  * Formats a SharedDiagnostic into the national SI-SIAO standard
  * and logs the transmission in the audit trail.
- * Production: HTTPS + mutual TLS to api.siao.gouv.fr
+ *
+ * FEATURE FLAG: SIAO_ENABLED must be 'true' for actual network calls.
+ * When disabled, returns { status: 'not_configured' }.
  */
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'POST') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
 
-    // Auth
-    const token = req.cookies?.pro_token;
-    if (!token) return res.status(401).json({ error: 'Non autorisé.' });
-    const user = verifyProToken(token);
-    if (!user) return res.status(401).json({ error: 'Session invalide.' });
+    const proCtx = requireProStructureContext(req, res);
+    if (!proCtx) return;
+
+    // Feature flag guard — no SIAO calls when disabled
+    const siaoEnabled = process.env.SIAO_ENABLED === 'true';
+    if (!siaoEnabled) {
+        return res.status(200).json({
+            ok: false,
+            status: 'not_configured',
+            message: 'L\'interopérabilité SI-SIAO n\'est pas encore activée. Contactez votre administrateur pour l\'activer.',
+        });
+    }
 
     const { shareId } = req.body || {};
     if (!shareId) {
@@ -47,7 +56,7 @@ export default async function handler(req, res) {
             transmission: {
                 id: transmissionId,
                 date: new Date().toISOString(),
-                emetteur: user.structureName || 'AccesDirectAide',
+                emetteur: proCtx.structureId,
                 version: '2.0',
             },
             demandeur: {
@@ -81,15 +90,15 @@ export default async function handler(req, res) {
                     transmissionStatus = 'TRANSMITTED';
                 } else {
                     const errText = await siaoRes.text().catch(() => '');
-                    console.error(`[SIAO] API error (${siaoRes.status}): ${errText}`);
+                    logger.error({ status: siaoRes.status, body: errText }, '[SIAO] API error');
                     transmissionStatus = 'FAILED';
                 }
             } catch (fetchErr) {
-                console.error(`[SIAO] Network error: ${fetchErr.message}`);
+                logger.error({ err: fetchErr }, '[SIAO] Network error');
                 transmissionStatus = 'NETWORK_ERROR';
             }
         } else {
-            console.warn(`[SIAO] API not configured — transmission ${transmissionId} logged locally`);
+            logger.warn({ transmissionId }, '[SIAO] API not configured — logged locally');
         }
 
         // Audit trail
@@ -98,7 +107,7 @@ export default async function handler(req, res) {
                 action: 'EXTERNAL_TRANSMISSION_SIAO',
                 entityId: shareId,
                 entityType: 'DIAGNOSTIC',
-                actorId: user.id || user.sub || 'system',
+                actorId: proCtx.userId,
                 details: JSON.stringify({
                     transmissionId,
                     destination: 'SI-SIAO National',
@@ -117,7 +126,9 @@ export default async function handler(req, res) {
             destination: 'SI-SIAO National',
         });
     } catch (error) {
-        logger.error('[SIAO] Erreur:', error.message);
+        logger.error({ err: error }, '[SIAO] Erreur');
         return res.status(500).json({ error: 'Échec interopérabilité nationale.' });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/mfa-setup.js
+++ b/api/_handlers/pro/mfa-setup.js
@@ -1,9 +1,10 @@
 import prisma from '../../_utils/prisma.js';
-import { requireAuth, logProAudit } from '../../lib/pro-auth.js';
+import { requireProAuth } from '../../_utils/auth.js';
+import { logProAudit } from '../../lib/pro-auth.js';
 import { generateSecret, verifyCode, buildOtpauthUrl } from '../../lib/totp.js';
 
 /**
- * MFA Setup handler
+ * MFA Setup handler (Pro-only)
  *
  * GET  → Generate secret + otpauth URL (does NOT enable MFA yet)
  * POST → Verify initial code → enable MFA
@@ -83,4 +84,5 @@ async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
 }
 
-export default requireAuth(handler);
+// Strict pro-only auth (not generic requireAuth)
+export default requireProAuth(handler);

--- a/api/_handlers/pro/regional-stats.js
+++ b/api/_handlers/pro/regional-stats.js
@@ -1,9 +1,10 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
-import { verifyProToken } from '../../lib/pro-auth.js';
+import { requireProAuth } from '../../_utils/auth.js';
+import logger from '../../_utils/logger.js';
 
 /**
- * Regional Stats API (Pro — Super-Admin / Observer)
+ * Regional Stats API (Pro — authenticated)
  *
  * GET /api/pro/regional-stats
  *
@@ -11,16 +12,10 @@ import { verifyProToken } from '../../lib/pro-auth.js';
  * Used by regional decision-makers for territorial dashboarding.
  * No individual dossier data is ever exposed.
  */
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'GET') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
-
-    // Auth
-    const token = req.cookies?.pro_token;
-    if (!token) return res.status(401).json({ error: 'Non autorisé.' });
-    const user = verifyProToken(token);
-    if (!user) return res.status(401).json({ error: 'Session invalide.' });
 
     try {
         // 1. Count structures
@@ -103,7 +98,9 @@ export default async function handler(req, res) {
             },
         });
     } catch (error) {
-        console.error('[RegionalStats] Erreur:', error.message);
+        logger.error({ err: error }, '[RegionalStats] Erreur');
         return res.status(500).json({ error: 'Erreur statistiques régionales.' });
     }
 }
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/system-maintenance.js
+++ b/api/_handlers/pro/system-maintenance.js
@@ -1,7 +1,8 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
-import { verifyProToken } from '../../lib/pro-auth.js';
+import { requireProRole } from '../../_utils/auth.js';
 import crypto from 'crypto';
+import logger from '../../_utils/logger.js';
 
 /**
  * System Maintenance API (Pro — Admin only)
@@ -12,16 +13,10 @@ import crypto from 'crypto';
  * BACKUP: Counts records, logs audit, returns backup metadata.
  * STRESS_TEST: Runs N rapid DB reads to benchmark latency.
  */
-export default async function handler(req, res) {
+async function handler(req, res) {
     if (req.method !== 'POST') {
         return res.status(405).json({ error: 'Méthode non autorisée' });
     }
-
-    // Auth
-    const token = req.cookies?.pro_token;
-    if (!token) return res.status(401).json({ error: 'Non autorisé.' });
-    const user = verifyProToken(token);
-    if (!user) return res.status(401).json({ error: 'Session invalide.' });
 
     const { action } = req.body || {};
 
@@ -42,7 +37,7 @@ export default async function handler(req, res) {
                     action: 'SYSTEM_BACKUP_GENERATED',
                     entityId: backupId,
                     entityType: 'SYSTEM',
-                    actorId: user.id || user.sub || 'admin',
+                    actorId: req.user?.userId || 'admin',
                     details: JSON.stringify({
                         diagnostics: diagCount,
                         auditEntries: auditCount,
@@ -85,7 +80,10 @@ export default async function handler(req, res) {
 
         return res.status(400).json({ error: 'Action invalide. Utilisez BACKUP ou STRESS_TEST.' });
     } catch (error) {
-        console.error('[Maintenance] Erreur:', error.message);
+        logger.error({ err: error }, '[Maintenance] Erreur');
         return res.status(500).json({ error: 'Échec opération système.' });
     }
 }
+
+// Admin-only: requires STRUCTURE_ADMIN or SUPERADMIN role
+export default requireProRole(handler, ['structure_admin', 'superadmin']);

--- a/tests/integration/p11a-pro-rbac-enforcement.test.js
+++ b/tests/integration/p11a-pro-rbac-enforcement.test.js
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+
+import apiHandler from '../../api/index.js';
+import { signProToken } from '../../api/lib/pro-auth.js';
+
+/**
+ * @param {{
+ *   method?: string,
+ *   url?: string,
+ *   headers?: Record<string, string>,
+ *   query?: Record<string, string>,
+ *   body?: unknown,
+ * }} overrides
+ */
+function createReq(overrides = {}) {
+    return {
+        method: overrides.method || 'GET',
+        url: overrides.url || '/api/pro/health-check',
+        headers: {
+            host: 'localhost:3000',
+            'x-forwarded-proto': 'http',
+            ...(overrides.headers || {}),
+        },
+        query: overrides.query || {},
+        body: overrides.body || null,
+        cookies: {},
+    };
+}
+
+function createRes() {
+    /** @type {Record<string, string>} */
+    const headers = {};
+    /** @type {Array<() => void>} */
+    const finishListeners = [];
+
+    return {
+        statusCode: 200,
+        body: null,
+        headersSent: false,
+        on(event, listener) {
+            if (event === 'finish' && typeof listener === 'function') finishListeners.push(listener);
+            return this;
+        },
+        setHeader(key, value) {
+            headers[String(key).toLowerCase()] = String(value);
+        },
+        getHeader(key) {
+            return headers[String(key).toLowerCase()];
+        },
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        writeHead(code, outHeaders = {}) {
+            this.statusCode = code;
+            for (const [key, value] of Object.entries(outHeaders)) {
+                headers[String(key).toLowerCase()] = String(value);
+            }
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            this.headersSent = true;
+            for (const listener of finishListeners) listener();
+            return this;
+        },
+        send(payload) {
+            this.body = payload;
+            this.headersSent = true;
+            for (const listener of finishListeners) listener();
+            return this;
+        },
+        end(payload) {
+            if (typeof payload !== 'undefined') this.body = payload;
+            this.headersSent = true;
+            for (const listener of finishListeners) listener();
+            return this;
+        },
+    };
+}
+
+/**
+ * @param {string} url
+ * @param {{
+ *   method?: string,
+ *   headers?: Record<string, string>,
+ *   body?: unknown,
+ * }} options
+ */
+async function invokeApi(url, options = {}) {
+    const req = createReq({
+        method: options.method,
+        url,
+        headers: options.headers,
+        body: options.body,
+    });
+    const res = createRes();
+    await apiHandler(req, res);
+    return res;
+}
+
+/**
+ * P11a — RBAC enforcement on all pro endpoints
+ *
+ * Verifies that:
+ * 1. All pro endpoints reject unauthenticated requests (401)
+ * 2. system-maintenance rejects non-admin pro users (403)
+ * 3. interop-siao returns not_configured when SIAO_ENABLED is false
+ */
+describe('P11a — Pro endpoint RBAC enforcement', () => {
+    const PRO_ENDPOINTS_GET = [
+        '/api/pro/health-check',
+        '/api/pro/regional-stats',
+        '/api/pro/attestation-data',
+        '/api/pro/mfa-setup',
+    ];
+
+    const PRO_ENDPOINTS_POST = [
+        '/api/pro/agent-scheduler',
+        '/api/pro/agent-discovery',
+        '/api/pro/consent',
+        '/api/pro/dossier-synthesis',
+        '/api/pro/interop-siao',
+        '/api/pro/system-maintenance',
+        '/api/pro/dossier/upload-secure',
+    ];
+
+    // ── No token → 401 ──
+    for (const url of PRO_ENDPOINTS_GET) {
+        it(`GET ${url} without token → 401`, async () => {
+            const res = await invokeApi(url, { method: 'GET' });
+            expect(res.statusCode).toBe(401);
+        });
+    }
+
+    for (const url of PRO_ENDPOINTS_POST) {
+        it(`POST ${url} without token → 401`, async () => {
+            const res = await invokeApi(url, { method: 'POST' });
+            expect(res.statusCode).toBe(401);
+        });
+    }
+
+    // ── With valid pro token → should NOT return 401 ──
+    it('GET /api/pro/mfa-setup with valid pro token → not 401', async () => {
+        const proToken = signProToken({
+            id: 'pro-rbac-test',
+            email: 'rbac@test.local',
+            structureId: 'structure-rbac',
+            role: 'PRO',
+        });
+
+        const res = await invokeApi('/api/pro/mfa-setup', {
+            method: 'GET',
+            headers: { authorization: `Bearer ${proToken}` },
+        });
+
+        // Should not be 401 (auth passed), may be other error (DB, etc.)
+        expect(res.statusCode).not.toBe(401);
+    });
+
+    // ── system-maintenance: admin-only, PRO role → 403 ──
+    it('POST /api/pro/system-maintenance with PRO role → 403', async () => {
+        const proToken = signProToken({
+            id: 'pro-rbac-test',
+            email: 'rbac@test.local',
+            structureId: 'structure-rbac',
+            role: 'PRO',
+        });
+
+        const res = await invokeApi('/api/pro/system-maintenance', {
+            method: 'POST',
+            headers: { authorization: `Bearer ${proToken}` },
+            body: { action: 'BACKUP' },
+        });
+
+        expect(res.statusCode).toBe(403);
+    });
+
+    it('POST /api/pro/system-maintenance with STRUCTURE_ADMIN role → not 403', async () => {
+        const adminToken = signProToken({
+            id: 'admin-rbac-test',
+            email: 'admin@test.local',
+            structureId: 'structure-rbac',
+            role: 'STRUCTURE_ADMIN',
+        });
+
+        const res = await invokeApi('/api/pro/system-maintenance', {
+            method: 'POST',
+            headers: { authorization: `Bearer ${adminToken}` },
+            body: { action: 'BACKUP' },
+        });
+
+        // Should pass auth (not 401/403), may fail on DB
+        expect(res.statusCode).not.toBe(401);
+        expect(res.statusCode).not.toBe(403);
+    });
+
+    // ── interop-siao: feature flag OFF → not_configured ──
+    it('POST /api/pro/interop-siao with SIAO_ENABLED=false → not_configured', async () => {
+        const originalSiao = process.env.SIAO_ENABLED;
+        process.env.SIAO_ENABLED = 'false';
+
+        const proToken = signProToken({
+            id: 'pro-siao-test',
+            email: 'siao@test.local',
+            structureId: 'structure-siao',
+            role: 'PRO',
+        });
+
+        const res = await invokeApi('/api/pro/interop-siao', {
+            method: 'POST',
+            headers: { authorization: `Bearer ${proToken}` },
+            body: { shareId: 'test-share' },
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject({
+            ok: false,
+            status: 'not_configured',
+        });
+
+        // Restore
+        if (originalSiao !== undefined) {
+            process.env.SIAO_ENABLED = originalSiao;
+        } else {
+            delete process.env.SIAO_ENABLED;
+        }
+    });
+});


### PR DESCRIPTION
## 🔐 PR1 Phase 2 — Security & RBAC Enforcement

### Résumé
Enforce RBAC sur TOUS les endpoints pro qui n'avaient pas de guards d'authentification standardisés + ajout du feature flag `SIAO_ENABLED`.

### Changements

| Fichier | Changement |
|---|---|
| `regional-stats.js` | `requireProAuth` wrapper |
| `attestation-data.js` | `requireProAuth` + `requireProStructureContext` |
| `system-maintenance.js` | `requireProRole(['structure_admin','superadmin'])` — **admin-only** |
| `agent-scheduler.js` | `requireProAuth` wrapper |
| `consent.js` | `requireProAuth` wrapper |
| `dossier/upload-secure.js` | `requireProAuth` + `requireProStructureContext` |
| `dossier-synthesis.js` | `requireProAuth` + `requireProStructureContext` |
| `agent-discovery.js` | Upgrade `requireAuth` → `requireProAuth` (strict pro-only) |
| `interop-siao.js` | `requireProAuth` + **`SIAO_ENABLED` feature flag** |
| `health-check.js` | `requireProAuth` wrapper |
| `mfa-setup.js` | Upgrade `requireAuth` → `requireProAuth` (strict pro-only) |

### Sécurité
- ✅ 11 handlers pro protégés par RBAC standardisé
- ✅ `system-maintenance` restreint aux rôles admin uniquement
- ✅ `interop-siao` ne fait **aucun appel réseau** si `SIAO_ENABLED=false`
- ✅ Tous les `console.error/warn` remplacés par `logger` structuré

### Tests
- ✅ **15/15 tests passent** — `p11a-pro-rbac-enforcement.test.js`
  - 401 sur tous les endpoints sans token
  - 403 sur system-maintenance avec rôle PRO
  - not_configured sur interop-siao avec SIAO_ENABLED=false

### Validation
```bash
npx vite build          # ✅ success (54.67s)
npx vitest run tests/integration/p11a-pro-rbac-enforcement.test.js  # ✅ 15/15 pass
```

### Variables d'environnement
| Variable | Défaut | Description |
|---|---|---|
| `SIAO_ENABLED` | `false` | Active l'interopérabilité SI-SIAO. Ne pas activer sans convention. |