### PR TITLE
feat(team+dossier): Phase 2 PR3 — Role change, RGPD export, view log

### DIFF
--- a/api/_handlers/pro/dossier.js
+++ b/api/_handlers/pro/dossier.js
@@ -2,6 +2,7 @@
 import prisma from '../../_utils/prisma.js';
 import { requireProAuth, requireProStructureContext } from '../../_utils/auth.js';
 import { logProAudit } from '../../lib/pro-auth.js';
+import logger from '../../_utils/logger.js';
 
 /**
  * Pro Dossier Handler
@@ -111,7 +112,7 @@ async function handler(req, res) {
 
         return res.status(405).json({ error: 'Méthode non autorisée' });
     } catch (error) {
-        console.error('[Pro Dossier] Erreur:', error.message);
+        logger.error({ err: error }, '[Pro Dossier] Erreur');
         return res.status(500).json({ error: 'Erreur serveur.' });
     }
 }

--- a/api/_handlers/pro/dossier/export.js
+++ b/api/_handlers/pro/dossier/export.js
@@ -1,0 +1,111 @@
+// @ts-nocheck
+import prisma from '../../../_utils/prisma.js';
+import { requireProAuth, requireProStructureContext } from '../../../_utils/auth.js';
+import { logProAudit } from '../../../lib/pro-auth.js';
+import logger from '../../../_utils/logger.js';
+
+/**
+ * Dossier Export API (Pro-only, RGPD)
+ *
+ * GET /api/pro/dossier/export?shareId=xxx&format=json|csv
+ *
+ * Exports a dossier's data in JSON or CSV format (RGPD data portability).
+ * Also logs the export action for audit compliance.
+ */
+async function handler(req, res) {
+    if (req.method !== 'GET') {
+        return res.status(405).json({ error: 'Méthode non autorisée' });
+    }
+
+    const proCtx = requireProStructureContext(req, res);
+    if (!proCtx) return;
+
+    const { userId, structureId } = proCtx;
+
+    const url = new URL(req.url || '/', `https://${req.headers?.host || 'localhost'}`);
+    const shareId = url.searchParams.get('shareId');
+    const format = url.searchParams.get('format') || 'json';
+
+    if (!shareId) {
+        return res.status(400).json({ error: 'shareId requis.' });
+    }
+
+    try {
+        const shared = await prisma.sharedDiagnostic.findUnique({
+            where: { id: shareId },
+        });
+
+        if (!shared) {
+            return res.status(404).json({ error: 'Dossier introuvable.' });
+        }
+
+        // Safe results (strip internal fields)
+        const safeResults = { ...(shared.results || {}) };
+        delete safeResults._files;
+        delete safeResults._consent;
+
+        const exportData = {
+            reference: shareId.slice(0, 8).toUpperCase(),
+            createdAt: shared.createdAt,
+            expiresAt: shared.expiresAt,
+            situation: shared.situation || {},
+            results: safeResults,
+            viewCount: shared.viewCount,
+            exportedAt: new Date().toISOString(),
+            exportedBy: userId,
+        };
+
+        // Audit
+        await logProAudit('DOSSIER_EXPORTED', userId, structureId, {
+            shareId,
+            format,
+        }, req.headers?.['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown');
+
+        // CSV format
+        if (format === 'csv') {
+            const situation = exportData.situation || {};
+            const rights = safeResults.rights || [];
+
+            const csvLines = [
+                'Champ,Valeur',
+                `Référence,${exportData.reference}`,
+                `Créé le,"${exportData.createdAt}"`,
+                `Expire le,"${exportData.expiresAt}"`,
+                `Vues,${exportData.viewCount}`,
+                '',
+                'Droits identifiés',
+                'Nom,Éligible,Montant estimé',
+            ];
+
+            for (const right of rights) {
+                csvLines.push(
+                    `"${(right.name || '').replace(/"/g, '""')}",${right.eligible ? 'Oui' : 'Non'},"${right.amount || 'N/A'}"`
+                );
+            }
+
+            csvLines.push('');
+            csvLines.push('Situation');
+            csvLines.push('Clé,Valeur');
+            for (const [key, value] of Object.entries(situation)) {
+                csvLines.push(`"${key}","${String(value).replace(/"/g, '""')}"`);
+            }
+
+            const csv = csvLines.join('\n');
+            res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+            res.setHeader('Content-Disposition', `attachment; filename="dossier-${exportData.reference}.csv"`);
+            return res.status(200).send(csv);
+        }
+
+        // JSON format (default)
+        res.setHeader('Content-Disposition', `attachment; filename="dossier-${exportData.reference}.json"`);
+        return res.status(200).json({
+            ok: true,
+            export: exportData,
+        });
+    } catch (error) {
+        logger.error({ err: error }, '[DossierExport] Erreur');
+        return res.status(500).json({ error: 'Erreur export.' });
+    }
+}
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/dossier/views.js
+++ b/api/_handlers/pro/dossier/views.js
@@ -1,0 +1,75 @@
+// @ts-nocheck
+import prisma from '../../../_utils/prisma.js';
+import { requireProAuth, requireProStructureContext } from '../../../_utils/auth.js';
+import logger from '../../../_utils/logger.js';
+
+/**
+ * Dossier View Log API (Pro-only, RGPD transparency)
+ *
+ * GET /api/pro/dossier/views?shareId=xxx
+ *
+ * Returns the audit log of who viewed a given dossier.
+ * Provides RGPD transparency: "Qui a vu mon dossier?"
+ */
+async function handler(req, res) {
+    if (req.method !== 'GET') {
+        return res.status(405).json({ error: 'Méthode non autorisée' });
+    }
+
+    const proCtx = requireProStructureContext(req, res);
+    if (!proCtx) return;
+
+    const url = new URL(req.url || '/', `https://${req.headers?.host || 'localhost'}`);
+    const shareId = url.searchParams.get('shareId');
+
+    if (!shareId) {
+        return res.status(400).json({ error: 'shareId requis.' });
+    }
+
+    try {
+        // Check dossier exists
+        const shared = await prisma.sharedDiagnostic.findUnique({
+            where: { id: shareId },
+            select: { id: true, viewCount: true },
+        });
+
+        if (!shared) {
+            return res.status(404).json({ error: 'Dossier introuvable.' });
+        }
+
+        // Get view audit logs
+        const viewLogs = await prisma.auditLog.findMany({
+            where: {
+                entityId: shareId,
+                action: { in: ['DOSSIER_VIEWED', 'DOSSIER_EXPORTED', 'DOSSIER_STATUS_UPDATED'] },
+            },
+            orderBy: { createdAt: 'desc' },
+            take: 50,
+            select: {
+                id: true,
+                action: true,
+                actorId: true,
+                createdAt: true,
+                details: true,
+            },
+        });
+
+        return res.status(200).json({
+            ok: true,
+            shareId,
+            viewCount: shared.viewCount,
+            views: viewLogs.map((log) => ({
+                id: log.id,
+                action: log.action,
+                actorId: log.actorId,
+                at: log.createdAt,
+                details: typeof log.details === 'string' ? JSON.parse(log.details) : log.details,
+            })),
+        });
+    } catch (error) {
+        logger.error({ err: error }, '[DossierViews] Erreur');
+        return res.status(500).json({ error: 'Erreur consultation.' });
+    }
+}
+
+export default requireProAuth(handler);

--- a/api/_handlers/pro/team.js
+++ b/api/_handlers/pro/team.js
@@ -1,12 +1,19 @@
-
+// @ts-nocheck
 import prisma from '../../_utils/prisma.js';
 import { logProAudit } from '../../lib/pro-auth.js';
 import { AUTH_ROLE, requireProRole, requireProStructureContext } from '../../_utils/auth.js';
-/**
- * @param {import('../../_utils/http-types').ApiRequest} req
- * @param {import('../../_utils/http-types').ApiResponse} res
- */
+import { createNotification } from './notifications.js';
+import logger from '../../_utils/logger.js';
 
+const VALID_ROLES = ['PRO', 'STRUCTURE_ADMIN', 'SUPERADMIN'];
+
+/**
+ * Team Management API (Admin-only)
+ *
+ * GET    /api/pro/team?page=1&limit=20 — List users + invitations (paginated)
+ * PATCH  /api/pro/team                 — Update user role
+ * DELETE /api/pro/team?userId=xxx      — Disable user
+ */
 async function handler(req, res) {
     const proCtx = requireProStructureContext(req, res);
     if (!proCtx) return;
@@ -14,43 +21,138 @@ async function handler(req, res) {
     const { structureId, userId } = proCtx;
 
     try {
+        // ── GET: List team with pagination ──
         if (req.method === 'GET') {
-            // List users + pending invitations
-            const users = await prisma.proUser.findMany({
-                where: { structureId },
-                select: { id: true, email: true, role: true, status: true, createdAt: true }
-            });
+            const url = new URL(req.url || '/', `https://${req.headers?.host || 'localhost'}`);
+            const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10));
+            const limit = Math.min(50, Math.max(1, parseInt(url.searchParams.get('limit') || '20', 10)));
+            const skip = (page - 1) * limit;
+
+            const [users, total] = await Promise.all([
+                prisma.proUser.findMany({
+                    where: { structureId },
+                    select: { id: true, email: true, role: true, status: true, createdAt: true },
+                    orderBy: { createdAt: 'desc' },
+                    take: limit,
+                    skip,
+                }),
+                prisma.proUser.count({ where: { structureId } }),
+            ]);
 
             const invitations = await prisma.invitation.findMany({
-                where: { structureId, used_at: null }
+                where: { structureId, used_at: null },
+                orderBy: { created_at: 'desc' },
+                take: 10,
             });
 
-            return res.status(200).json({ users, invitations });
+            return res.status(200).json({
+                users,
+                invitations,
+                pagination: {
+                    page,
+                    limit,
+                    total,
+                    totalPages: Math.ceil(total / limit),
+                },
+            });
+        }
 
-        } else if (req.method === 'DELETE') {
-            // Disable user (Soft delete or status change)
-            // Query param: userId
-            const { userId: targetUserId } = req.query;
+        // ── PATCH: Update user role ──
+        if (req.method === 'PATCH') {
+            const { targetUserId, role } = req.body || {};
 
-            if (!targetUserId) return res.status(400).json({ error: "Missing userId" });
-            if (targetUserId === userId) return res.status(400).json({ error: "Cannot disable yourself" });
+            if (!targetUserId || !role) {
+                return res.status(400).json({ error: 'targetUserId et role requis.' });
+            }
 
-            const targetUser = await prisma.proUser.findFirst({ where: { id: targetUserId, structureId } });
-            if (!targetUser) return res.status(404).json({ error: "User not found" });
+            if (!VALID_ROLES.includes(role)) {
+                return res.status(400).json({
+                    error: `Rôle invalide. Valeurs acceptées: ${VALID_ROLES.join(', ')}`,
+                });
+            }
+
+            if (targetUserId === userId) {
+                return res.status(400).json({ error: 'Impossible de modifier son propre rôle.' });
+            }
+
+            // Verify target user belongs to same structure
+            const targetUser = await prisma.proUser.findFirst({
+                where: { id: targetUserId, structureId },
+            });
+
+            if (!targetUser) {
+                return res.status(404).json({ error: 'Utilisateur introuvable dans cette structure.' });
+            }
+
+            const previousRole = targetUser.role;
 
             await prisma.proUser.update({
                 where: { id: targetUserId },
-                data: { status: 'disabled' }
+                data: { role },
             });
 
-            await logProAudit('USER_DISABLED', userId, structureId, { targetUserId }, req.socket.remoteAddress);
-            return res.status(200).json({ success: true });
-        } else {
-            return res.status(405).json({ error: "Method not allowed" });
+            // Audit
+            await logProAudit('USER_ROLE_CHANGED', userId, structureId, {
+                targetUserId,
+                previousRole,
+                newRole: role,
+            }, req.headers?.['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown');
+
+            // Notify target user
+            await createNotification({
+                userId: targetUserId,
+                structureId,
+                type: 'team_role_change',
+                title: 'Votre rôle a été modifié',
+                message: `Votre rôle a été changé de ${previousRole} à ${role}.`,
+                metadata: { previousRole, newRole: role, changedBy: userId },
+            });
+
+            return res.status(200).json({
+                ok: true,
+                targetUserId,
+                previousRole,
+                newRole: role,
+            });
         }
-    } catch (e) {
-        console.error("Team API Error", e);
-        return res.status(500).json({ error: "Internal Error" });
+
+        // ── DELETE: Disable user ──
+        if (req.method === 'DELETE') {
+            const url = new URL(req.url || '/', `https://${req.headers?.host || 'localhost'}`);
+            const targetUserId = url.searchParams.get('userId') || req.query?.userId;
+
+            if (!targetUserId) {
+                return res.status(400).json({ error: 'userId requis.' });
+            }
+
+            if (targetUserId === userId) {
+                return res.status(400).json({ error: 'Impossible de se désactiver soi-même.' });
+            }
+
+            const targetUser = await prisma.proUser.findFirst({
+                where: { id: targetUserId, structureId },
+            });
+
+            if (!targetUser) {
+                return res.status(404).json({ error: 'Utilisateur introuvable.' });
+            }
+
+            await prisma.proUser.update({
+                where: { id: targetUserId },
+                data: { status: 'disabled' },
+            });
+
+            await logProAudit('USER_DISABLED', userId, structureId, {
+                targetUserId,
+            }, req.headers?.['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown');
+
+            return res.status(200).json({ ok: true });
+        }
+
+        return res.status(405).json({ error: 'Méthode non autorisée' });
+    } catch (error) {
+        logger.error({ err: error }, '[Team] Erreur');
+        return res.status(500).json({ error: 'Erreur interne.' });
     }
 }
 

--- a/api/routes.js
+++ b/api/routes.js
@@ -55,6 +55,8 @@ import proNotifications from './_handlers/pro/notifications.js';
 import proAudit from './_handlers/pro/audit.js';
 import proReports from './_handlers/pro/reports.js';
 import proDossierUpload from './_handlers/pro/dossier/upload-secure.js';
+import proDossierExport from './_handlers/pro/dossier/export.js';
+import proDossierViews from './_handlers/pro/dossier/views.js';
 import proConsent from './_handlers/pro/consent.js';
 import proDossierSynthesis from './_handlers/pro/dossier-synthesis.js';
 import proRegionalStats from './_handlers/pro/regional-stats.js';
@@ -196,6 +198,8 @@ export const routes = [
     { path: 'pro/audit', match: 'exact', handler: proAudit },
     { path: 'pro/reports', match: 'exact', handler: proReports },
     { path: 'pro/dossier/upload-secure', match: 'exact', handler: proDossierUpload },
+    { path: 'pro/dossier/export', match: 'exact', handler: proDossierExport },
+    { path: 'pro/dossier/views', match: 'exact', handler: proDossierViews },
     { path: 'pro/consent', match: 'exact', handler: proConsent },
     { path: 'pro/dossier-synthesis', match: 'exact', handler: proDossierSynthesis },
     { path: 'pro/regional-stats', match: 'exact', handler: proRegionalStats },


### PR DESCRIPTION
## 👥 PR3 Phase 2 — Dashboard + Team + Dossier

### Résumé
Endpoints manquants pour la gestion d'équipe (changement de rôle) et la conformité RGPD (export dossier, traçabilité des accès).

### Changements

| Fichier | Description |
|---|---|
| `team.js` | **PATCH** role change + validation + audit + notification in-app |
| `team.js` | **GET** pagination (`page`, `limit`, `totalPages`) |
| `dossier/export.js` | **Nouveau** — Export JSON/CSV (RGPD portabilité) |
| `dossier/views.js` | **Nouveau** — "Qui a vu mon dossier?" (traçabilité RGPD) |
| `dossier.js` | Replace `console.error` → `logger` |
| `routes.js` | 2 nouvelles routes enregistrées |

### API nouvelles

```
PATCH /api/pro/team         → { targetUserId, role }   (admin-only)
GET   /api/pro/dossier/export?shareId=xxx&format=json|csv
GET   /api/pro/dossier/views?shareId=xxx
```

### Sécurité
- ✅ Team PATCH: validation rôle, auto-modification bloquée, audit + notification
- ✅ Dossier export: filtre les champs internes (`_files`, `_consent`)
- ✅ Dossier views: RGPD transparence via AuditLog

### Validation
```bash
npx vite build  # ✅ success (32.63s)
```