### PR TITLE
feat(tests+docs): Phase 2 PR5 — Integration tests + API docs + Runbook

### DIFF
--- a/docs/API-PRO-REFERENCE.md
+++ b/docs/API-PRO-REFERENCE.md
@@ -1,0 +1,129 @@
+# Espace Pro — API Reference
+
+## Authentication
+
+All pro endpoints require a JWT Bearer token:
+```
+Authorization: Bearer <pro_token>
+```
+
+Tokens are obtained via `POST /api/pro/login`.
+
+---
+
+## Endpoints
+
+### 🔐 Auth & Security
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| POST | `/api/pro/login` | Public | Login pro user |
+| POST | `/api/pro/register` | Public | Register pro user |
+| GET | `/api/pro/me` | Pro | Current user info |
+| GET/POST | `/api/pro/mfa-setup` | Pro | MFA TOTP setup |
+| GET | `/api/pro/health-check` | Pro | System health status |
+
+### 📅 Rendez-vous
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| GET/POST | `/api/pro/appointments` | Pro | List/create appointments |
+| GET/PATCH | `/api/pro/appointment/:id` | Pro | Get/update appointment |
+| POST | `/api/pro/start-visio` | Pro | Launch video call for RDV |
+
+### 💬 Messages
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| GET/POST | `/api/pro/messages` | Pro | List/send messages |
+
+### 🔔 Notifications
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| GET | `/api/pro/notifications` | Pro | List notifications (paginated) |
+| PATCH | `/api/pro/notifications` | Pro | Mark read/unread |
+
+**GET params:** `?page=1&limit=20&unread=true`
+
+**PATCH body:**
+```json
+{ "ids": ["id1", "id2"], "action": "read" }
+```
+
+### 👥 Équipe (Admin-only)
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| GET | `/api/pro/team` | Admin | List team members (paginated) |
+| PATCH | `/api/pro/team` | Admin | Change user role |
+| DELETE | `/api/pro/team?userId=xxx` | Admin | Disable user |
+
+**GET params:** `?page=1&limit=20`
+
+**PATCH body:**
+```json
+{ "targetUserId": "xxx", "role": "STRUCTURE_ADMIN" }
+```
+
+Valid roles: `PRO`, `STRUCTURE_ADMIN`, `SUPERADMIN`
+
+### 📁 Dossiers
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| GET | `/api/pro/dossier?shareId=xxx` | Pro | View shared diagnostic |
+| PATCH | `/api/pro/dossier?shareId=xxx` | Pro | Update follow-up status |
+| POST | `/api/pro/dossier/upload-secure` | Pro | Upload secure document |
+| GET | `/api/pro/dossier/export?shareId=xxx&format=json` | Pro | Export dossier (RGPD) |
+| GET | `/api/pro/dossier/views?shareId=xxx` | Pro | View access log (RGPD) |
+| POST | `/api/pro/dossier-synthesis` | Pro | Generate AI synthesis |
+| POST | `/api/pro/consent` | Pro | Record consent |
+
+### 🔌 Intégrations
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| POST | `/api/pro/interop-siao` | Pro | SI-SIAO data exchange (feature-flagged) |
+| GET | `/api/pro/outlook?action=authorize` | Pro | Start Outlook OAuth |
+| GET | `/api/pro/outlook?action=callback&code=xxx` | Pro | OAuth callback |
+| GET | `/api/pro/outlook?action=status` | Pro | Check Outlook connection |
+| POST | `/api/pro/outlook?action=disconnect` | Pro | Disconnect Outlook |
+
+### 📊 Rapports
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| GET | `/api/pro/regional-stats` | Pro | Regional statistics |
+| GET | `/api/pro/attestation-data` | Pro | Attestation generation data |
+| GET | `/api/pro/reports` | Pro | Impact reports |
+| GET | `/api/pro/team-stats` | Pro | Team performance stats |
+
+### ⚙️ Système (Admin-only)
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| POST | `/api/pro/system-maintenance` | Admin | System maintenance (backup, cleanup) |
+| POST | `/api/pro/agent-scheduler` | Pro | Trigger agent scheduler |
+| POST | `/api/pro/agent-discovery` | Pro | AI agent discovery |
+
+---
+
+## Error Codes
+
+| Code | Meaning |
+|---|---|
+| 400 | Bad Request (missing/invalid params) |
+| 401 | Unauthorized (missing/invalid token) |
+| 403 | Forbidden (insufficient role) |
+| 404 | Not Found |
+| 405 | Method Not Allowed |
+| 410 | Gone (expired resource) |
+| 500 | Internal Server Error |
+
+## Feature Flags
+
+| Variable | Default | Description |
+|---|---|---|
+| `SIAO_ENABLED` | `false` | Enable SI-SIAO interoperability |
+| `OUTLOOK_ENABLED` | `false` | Enable Outlook OAuth integration |

--- a/docs/RUNBOOK-PHASE2.md
+++ b/docs/RUNBOOK-PHASE2.md
@@ -1,0 +1,86 @@
+# Phase 2 — Espace Pro Runbook
+
+## Deployment Checklist
+
+### Environment Variables (Vercel)
+
+| Variable | Required | Description |
+|---|---|---|
+| `DATABASE_URL` | ✅ | PostgreSQL (Neon) connection string |
+| `DIRECT_URL` | ✅ | Direct PostgreSQL URL (migrations) |
+| `PRO_JWT_SECRET` | ✅ | JWT signing secret for pro tokens |
+| `CRON_SECRET` | ✅ | Secret for cron job authentication |
+| `MAILER_PROVIDER` | ✅ | Email provider (`mailjet`, `resend`, `noop`) |
+| `MAILER_API_KEY` | ✅ | `publicKey:secretKey` for Mailjet |
+| `MAILER_FROM` | ✅ | Sender email address |
+| `SIAO_ENABLED` | ❌ | `true` to enable SI-SIAO (default: false) |
+| `SIAO_API_URL` | ❌ | SI-SIAO API endpoint |
+| `SIAO_API_KEY` | ❌ | SI-SIAO API key |
+| `OUTLOOK_ENABLED` | ❌ | `true` to enable Outlook OAuth (default: false) |
+| `OUTLOOK_CLIENT_ID` | ❌ | Azure AD App Client ID |
+| `OUTLOOK_CLIENT_SECRET` | ❌ | Azure AD App Client Secret |
+| `OUTLOOK_REDIRECT_URI` | ❌ | Outlook OAuth callback URL |
+| `GEMINI_API_KEY` | ✅ | Google Gemini 2.0 Flash API key |
+
+### Cron Jobs (Vercel)
+
+| Job | Schedule | Description |
+|---|---|---|
+| `/api/cron/rdv-reminder` | `0 8 * * *` | RDV J-1 email + notification |
+| `/api/cron/actualites` | `0 */6 * * *` | RSS news ingestion |
+| `/api/cron/ingest-aids` | `0 3 * * *` | Aid data ingestion |
+| `/api/cron/ingest-structures` | `0 2 * * 0` | Structure data (weekly) |
+| `/api/cron/review-queue/scan` | `30 */6 * * *` | Content review queue |
+| `/api/cron/hive-scan` | `0 6 * * 1` | Hive orchestration (weekly) |
+
+### Database Migrations
+
+```bash
+# Local
+npx prisma migrate dev
+
+# Production (Vercel build)
+npx prisma migrate deploy
+# Fallback if P3015 error:
+npx prisma db push --accept-data-loss
+```
+
+### Post-Deploy Verification
+
+```bash
+# 1. Health check
+curl -H "Authorization: Bearer $TOKEN" https://YOUR-APP.vercel.app/api/pro/health-check
+
+# 2. Cron smoke test
+curl -H "Authorization: Bearer $CRON_SECRET" https://YOUR-APP.vercel.app/api/cron/rdv-reminder?mode=smoke
+
+# 3. Verify RBAC (should return 401)
+curl https://YOUR-APP.vercel.app/api/pro/team
+```
+
+## Feature Activation
+
+### SI-SIAO (DO NOT ACTIVATE without signed convention)
+1. Set `SIAO_ENABLED=true` in Vercel
+2. Set `SIAO_API_URL` and `SIAO_API_KEY`
+3. Test in staging first
+4. See `docs/SI-SIAO-INTEGRATION.md` for data mapping
+
+### Outlook
+1. Create Azure AD App Registration
+2. Set `OUTLOOK_ENABLED=true` + `CLIENT_ID/SECRET/REDIRECT_URI`
+3. Test OAuth flow on staging
+
+## Monitoring
+
+- **Sentry**: All unhandled errors are captured
+- **Structured Logging**: All handlers use `logger` (JSON format)
+- **Audit Log**: All sensitive actions logged to `AuditLog` table
+- **Cron Runs**: Tracked in `CronRun` table with status/metrics
+
+## Incident Response
+
+1. Check `/api/pro/health-check` for system status
+2. Review Sentry for recent errors
+3. Check `CronRun` table for failed cron jobs
+4. Review `AuditLog` for suspicious activity

--- a/tests/integration/p12-team-dossier-notifications.test.js
+++ b/tests/integration/p12-team-dossier-notifications.test.js
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+
+import apiHandler from '../../api/index.js';
+import { signProToken } from '../../api/lib/pro-auth.js';
+
+function createReq(overrides = {}) {
+    return {
+        method: overrides.method || 'GET',
+        url: overrides.url || '/api/pro/team',
+        headers: {
+            host: 'localhost:3000',
+            'x-forwarded-proto': 'http',
+            ...(overrides.headers || {}),
+        },
+        query: overrides.query || {},
+        body: overrides.body || null,
+        cookies: {},
+    };
+}
+
+function createRes() {
+    const headers = {};
+    const finishListeners = [];
+    return {
+        statusCode: 200,
+        body: null,
+        headersSent: false,
+        on(event, listener) {
+            if (event === 'finish' && typeof listener === 'function') finishListeners.push(listener);
+            return this;
+        },
+        setHeader(key, value) { headers[String(key).toLowerCase()] = String(value); },
+        getHeader(key) { return headers[String(key).toLowerCase()]; },
+        status(code) { this.statusCode = code; return this; },
+        writeHead(code, outHeaders = {}) {
+            this.statusCode = code;
+            for (const [key, value] of Object.entries(outHeaders)) headers[String(key).toLowerCase()] = String(value);
+            return this;
+        },
+        json(payload) { this.body = payload; this.headersSent = true; for (const l of finishListeners) l(); return this; },
+        send(payload) { this.body = payload; this.headersSent = true; for (const l of finishListeners) l(); return this; },
+        end(payload) { if (payload !== undefined) this.body = payload; this.headersSent = true; for (const l of finishListeners) l(); return this; },
+    };
+}
+
+async function invokeApi(url, options = {}) {
+    const req = createReq({ method: options.method, url, headers: options.headers, body: options.body });
+    const res = createRes();
+    await apiHandler(req, res);
+    return res;
+}
+
+/**
+ * P12 — Team, Dossier, and Notifications integration tests
+ */
+describe('P12 — Team management', () => {
+    const adminToken = signProToken({
+        id: 'admin-team-test',
+        email: 'admin@test.local',
+        structureId: 'structure-team',
+        role: 'STRUCTURE_ADMIN',
+    });
+
+    const proToken = signProToken({
+        id: 'pro-team-test',
+        email: 'pro@test.local',
+        structureId: 'structure-team',
+        role: 'PRO',
+    });
+
+    it('GET /api/pro/team without token → 401', async () => {
+        const res = await invokeApi('/api/pro/team');
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('GET /api/pro/team with PRO role → 403 (admin-only)', async () => {
+        const res = await invokeApi('/api/pro/team', {
+            headers: { authorization: `Bearer ${proToken}` },
+        });
+        expect(res.statusCode).toBe(403);
+    });
+
+    it('GET /api/pro/team with admin token → not 401/403', async () => {
+        const res = await invokeApi('/api/pro/team', {
+            headers: { authorization: `Bearer ${adminToken}` },
+        });
+        expect(res.statusCode).not.toBe(401);
+        expect(res.statusCode).not.toBe(403);
+    });
+
+    it('PATCH /api/pro/team without targetUserId → 400', async () => {
+        const res = await invokeApi('/api/pro/team', {
+            method: 'PATCH',
+            headers: {
+                authorization: `Bearer ${adminToken}`,
+                'content-type': 'application/json',
+            },
+            body: { role: 'STRUCTURE_ADMIN' },
+        });
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('PATCH /api/pro/team with invalid role → 400', async () => {
+        const res = await invokeApi('/api/pro/team', {
+            method: 'PATCH',
+            headers: {
+                authorization: `Bearer ${adminToken}`,
+                'content-type': 'application/json',
+            },
+            body: { targetUserId: 'someone', role: 'INVALID' },
+        });
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('PATCH /api/pro/team self-role-change → 400', async () => {
+        const res = await invokeApi('/api/pro/team', {
+            method: 'PATCH',
+            headers: {
+                authorization: `Bearer ${adminToken}`,
+                'content-type': 'application/json',
+            },
+            body: { targetUserId: 'admin-team-test', role: 'PRO' },
+        });
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('P12 — Dossier export', () => {
+    it('GET /api/pro/dossier/export without token → 401', async () => {
+        const res = await invokeApi('/api/pro/dossier/export?shareId=abc');
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('GET /api/pro/dossier/export without shareId → 400', async () => {
+        const token = signProToken({
+            id: 'pro-dossier-test',
+            email: 'dossier@test.local',
+            structureId: 'structure-dossier',
+            role: 'PRO',
+        });
+        const res = await invokeApi('/api/pro/dossier/export', {
+            headers: { authorization: `Bearer ${token}` },
+        });
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('GET /api/pro/dossier/views without shareId → 400', async () => {
+        const token = signProToken({
+            id: 'pro-views-test',
+            email: 'views@test.local',
+            structureId: 'structure-views',
+            role: 'PRO',
+        });
+        const res = await invokeApi('/api/pro/dossier/views', {
+            headers: { authorization: `Bearer ${token}` },
+        });
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('P12 — Notifications CRUD', () => {
+    const proToken = signProToken({
+        id: 'pro-notif-test',
+        email: 'notif@test.local',
+        structureId: 'structure-notif',
+        role: 'PRO',
+    });
+
+    it('GET /api/pro/notifications without token → 401', async () => {
+        const res = await invokeApi('/api/pro/notifications');
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('PATCH /api/pro/notifications without ids → 400', async () => {
+        const res = await invokeApi('/api/pro/notifications', {
+            method: 'PATCH',
+            headers: {
+                authorization: `Bearer ${proToken}`,
+                'content-type': 'application/json',
+            },
+            body: { action: 'read' },
+        });
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('PATCH /api/pro/notifications with invalid action → 400', async () => {
+        const res = await invokeApi('/api/pro/notifications', {
+            method: 'PATCH',
+            headers: {
+                authorization: `Bearer ${proToken}`,
+                'content-type': 'application/json',
+            },
+            body: { ids: ['abc'], action: 'invalid' },
+        });
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('P12 — Outlook OAuth', () => {
+    it('GET /api/pro/outlook without token → 401', async () => {
+        const res = await invokeApi('/api/pro/outlook?action=status');
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('GET /api/pro/outlook with token, OUTLOOK_ENABLED=false → not_configured', async () => {
+        const originalVal = process.env.OUTLOOK_ENABLED;
+        process.env.OUTLOOK_ENABLED = 'false';
+
+        const token = signProToken({
+            id: 'pro-outlook-test',
+            email: 'outlook@test.local',
+            structureId: 'structure-outlook',
+            role: 'PRO',
+        });
+
+        const res = await invokeApi('/api/pro/outlook?action=status', {
+            headers: { authorization: `Bearer ${token}` },
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject({ ok: false, status: 'not_configured' });
+
+        if (originalVal !== undefined) process.env.OUTLOOK_ENABLED = originalVal;
+        else delete process.env.OUTLOOK_ENABLED;
+    });
+});


### PR DESCRIPTION
## 🧪 PR5 Phase 2 — Tests + Documentation

### Résumé
Tests d'intégration couvrant les endpoints PR1-PR4 + documentation API complète + Runbook opérationnel.

### Changements

| Fichier | Description |
|---|---|
| `p12-team-dossier-notifications.test.js` | 14 tests: team RBAC, role change, dossier export, notifications CRUD, Outlook OAuth |
| `API-PRO-REFERENCE.md` | **Nouveau** — Référence API complète (tous endpoints, auth, params, erreurs) |
| `RUNBOOK-PHASE2.md` | **Nouveau** — Guide opérationnel (env vars, crons, deploy, incident response) |

### Tests
```
✓ P12 — Team management (6 tests)
  - GET without token → 401
  - GET with PRO role → 403 (admin-only)
  - GET with admin token → OK
  - PATCH without targetUserId → 400
  - PATCH with invalid role → 400
  - PATCH self-role-change → 400

✓ P12 — Dossier export (3 tests)
  - GET /export without token → 401
  - GET /export without shareId → 400
  - GET /views without shareId → 400

✓ P12 — Notifications CRUD (3 tests)
  - GET without token → 401
  - PATCH without ids → 400
  - PATCH with invalid action → 400

✓ P12 — Outlook OAuth (2 tests)
  - GET without token → 401
  - GET with OUTLOOK_ENABLED=false → not_configured
```

### Validation
```bash
npx vitest run tests/integration/p12-team-dossier-notifications.test.js  # ✅ 14/14 pass
```

---

### 📋 Phase 2 Complete Summary

| PR | Description | Tests | Status |
|---|---|---|---|
| [#284](https://github.com/Gokhangurbuz92/acces-direct-aide-b6066dd3/pull/284) | Security & RBAC | 15/15 | ✅ |
| [#285](https://github.com/Gokhangurbuz92/acces-direct-aide-b6066dd3/pull/285) | Notifications + Email J-1 | — | ✅ |
| [#286](https://github.com/Gokhangurbuz92/acces-direct-aide-b6066dd3/pull/286) | Team + Dossier RGPD | — | ✅ |
| [#287](https://github.com/Gokhangurbuz92/acces-direct-aide-b6066dd3/pull/287) | Interop + UX | — | ✅ |
| **#288** | **Tests + Docs** | **14/14** | ✅ |