### PR TITLE
fix(build): Skeleton import casing (P0-01)

### DIFF
--- a/src/components/ui/Skeleton.jsx
+++ b/src/components/ui/Skeleton.jsx
@@ -6,7 +6,7 @@
  *   <Skeleton className="h-12 w-12 rounded-full" /> — avatar
  *   <Skeleton variant="card" />               — full card skeleton
  */
-export default function Skeleton({ className = '', variant = 'line' }) {
+function Skeleton({ className = '', variant = 'line' }) {
     if (variant === 'card') {
         return (
             <div className="rounded-2xl border border-slate-100 p-4 space-y-3 animate-pulse">
@@ -55,3 +55,6 @@ export function SkeletonList({ count = 3, variant = 'card' }) {
         </div>
     );
 }
+
+export { Skeleton };
+export default Skeleton;


### PR DESCRIPTION
## Objectif

Corriger le build production cassé (P0-01 de l'audit Phase 2).

## Contexte

`Skeleton.jsx` utilisait uniquement `export default` mais 6 fichiers l'importent via `import { Skeleton }` (named import). Sur macOS (case-insensitive), tout fonctionne. Sur Linux/Vercel (case-sensitive), Vite ne résout pas correctement et le build échoue.

## Changement

Ajout d'un `export { Skeleton }` named export dans `Skeleton.jsx` aux côtés du `export default Skeleton`, rendant les deux formes d'import valides.

**1 fichier modifié, 4 lignes ajoutées, 1 supprimée.**

## Validation

```
✅ npm run build         → Build passes (exit code 0)
✅ npx vitest run        → 92 test files, 461 tests passed
✅ Zero changement fonctionnel
```

## Risques / Rollback

Risque nul — ajout d'une forme d'export supplémentaire sans modification fonctionnelle.

## DoD
- [x] `npm run build` OK
- [x] 461/461 tests passent
- [x] Zéro changement fonctionnel