### PR TITLE
fix(phase2): logger + env centralization + P3 tests → 100%

### DIFF
--- a/api/_handlers/auth/outlook-callback.js
+++ b/api/_handlers/auth/outlook-callback.js
@@ -15,6 +15,7 @@ import logger from '../../_utils/logger.js';
  */
 
 import prisma from '../../_utils/prisma.js';
+import { env } from '../../_utils/env.js';
 
 export default async function handler(req, res) {
     if (req.method === 'OPTIONS') {
@@ -33,9 +34,9 @@ export default async function handler(req, res) {
         return res.status(400).json({ error: "Code d'autorisation manquant" });
     }
 
-    const clientId = process.env.OUTLOOK_CLIENT_ID;
-    const clientSecret = process.env.OUTLOOK_CLIENT_SECRET;
-    const redirectUri = process.env.OUTLOOK_REDIRECT_URI;
+    const clientId = env.outlook.clientId;
+    const clientSecret = env.outlook.clientSecret;
+    const redirectUri = env.outlook.redirectUri;
 
     if (!clientId || !clientSecret || !redirectUri) {
         logger.error('[Outlook Auth] Variables d\'environnement manquantes');

--- a/api/_handlers/pro/health-check.js
+++ b/api/_handlers/pro/health-check.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import prisma from '../../_utils/prisma.js';
+import { env } from '../../_utils/env.js';
 import { requireProAuth } from '../../_utils/auth.js';
 import logger from '../../_utils/logger.js';
 
@@ -51,7 +52,7 @@ async function handler(req, res) {
         });
 
         // 6. Service status inference
-        const siaEnabled = process.env.SIAO_ENABLED === 'true';
+        const siaEnabled = env.siao.enabled;
         const services = [
             {
                 id: 'db',
@@ -64,7 +65,7 @@ async function handler(req, res) {
                 id: 'ai',
                 label: 'Moteur IA',
                 sub: 'Gemini 2.0 Flash',
-                status: process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY ? 'operational' : 'not_configured',
+                status: env.ai.geminiKey ? 'operational' : 'not_configured',
             },
             {
                 id: 'storage',
@@ -76,7 +77,7 @@ async function handler(req, res) {
                 id: 'siao',
                 label: 'Passerelle SIAO',
                 sub: 'Interop National',
-                status: siaEnabled && process.env.SIAO_API_URL ? 'operational' : 'not_configured',
+                status: siaEnabled && env.siao.apiUrl ? 'operational' : 'not_configured',
             },
         ];
 
@@ -94,7 +95,7 @@ async function handler(req, res) {
                 structuresCount,
                 appointmentsThisMonth,
             },
-            env: process.env.NODE_ENV || 'development',
+            env: env.runtime.nodeEnv,
             nodeVersion: process.version,
             timestamp: new Date().toISOString(),
         });

--- a/api/_handlers/pro/interop-siao.js
+++ b/api/_handlers/pro/interop-siao.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import logger from '../../_utils/logger.js';
 import prisma from '../../_utils/prisma.js';
+import { env } from '../../_utils/env.js';
 import { requireProAuth, requireProStructureContext } from '../../_utils/auth.js';
 import crypto from 'crypto';
 
@@ -25,7 +26,7 @@ async function handler(req, res) {
     if (!proCtx) return;
 
     // Feature flag guard — no SIAO calls when disabled
-    const siaoEnabled = process.env.SIAO_ENABLED === 'true';
+    const siaoEnabled = env.siao.enabled;
     if (!siaoEnabled) {
         return res.status(200).json({
             ok: false,
@@ -70,7 +71,7 @@ async function handler(req, res) {
         };
 
         // Transmit to SI-SIAO national API (if configured)
-        const siaoUrl = process.env.SIAO_API_URL;
+        const siaoUrl = env.siao.apiUrl;
         let transmissionStatus = 'LOCAL_ONLY';
 
         if (siaoUrl) {
@@ -80,7 +81,7 @@ async function handler(req, res) {
                     headers: {
                         'Content-Type': 'application/json',
                         'X-ADA-Transmission-Id': transmissionId,
-                        ...(process.env.SIAO_API_KEY ? { Authorization: `Bearer ${process.env.SIAO_API_KEY}` } : {}),
+                        ...(env.siao.apiKey ? { Authorization: `Bearer ${env.siao.apiKey}` } : {}),
                     },
                     body: JSON.stringify(siaoPayload),
                     signal: AbortSignal.timeout(15000),

--- a/api/_handlers/pro/outlook-availability.js
+++ b/api/_handlers/pro/outlook-availability.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import logger from '../../_utils/logger.js';
 import prisma from '../../_utils/prisma.js';
+import { env } from '../../_utils/env.js';
 import { requireProAuth, requireProStructureContext } from '../../_utils/auth.js';
 
 /**
@@ -21,8 +22,8 @@ import { requireProAuth, requireProStructureContext } from '../../_utils/auth.js
  * @returns {Promise<string|null>} fresh access_token or null if refresh failed
  */
 async function refreshOutlookToken(settings, structureId) {
-    const clientId = process.env.OUTLOOK_CLIENT_ID;
-    const clientSecret = process.env.OUTLOOK_CLIENT_SECRET;
+    const clientId = env.outlook.clientId;
+    const clientSecret = env.outlook.clientSecret;
     const refreshToken = settings.outlookRefreshToken;
 
     if (!clientId || !clientSecret || !refreshToken) {
@@ -64,7 +65,7 @@ async function refreshOutlookToken(settings, structureId) {
             },
         });
 
-        console.info('[Outlook Availability] Token refreshed for structure:', structureId);
+        logger.info('[Outlook Availability] Token refreshed for structure:', structureId);
         return tokens.access_token;
     } catch (err) {
         logger.error('[Outlook Availability] Token refresh error:', err.message);
@@ -111,7 +112,7 @@ async function handler(req, res) {
         let currentToken = settings.outlookToken;
         const expiresAt = settings.outlookTokenExpiresAt;
         if (expiresAt && new Date(expiresAt) <= new Date()) {
-            console.info('[Outlook Availability] Token expiré, tentative de refresh...');
+            logger.info('[Outlook Availability] Token expiré, tentative de refresh...');
             const refreshed = await refreshOutlookToken(settings, proCtx.structureId);
             if (!refreshed) {
                 return res.status(401).json({

--- a/api/_handlers/pro/outlook.js
+++ b/api/_handlers/pro/outlook.js
@@ -4,11 +4,12 @@ import logger from '../../_utils/logger.js';
 import prisma from '../../_utils/prisma.js';
 import crypto from 'crypto';
 
-const OUTLOOK_CLIENT_ID = process.env.OUTLOOK_CLIENT_ID || '';
-const OUTLOOK_CLIENT_SECRET = process.env.OUTLOOK_CLIENT_SECRET || '';
-const OUTLOOK_REDIRECT_URI = process.env.OUTLOOK_REDIRECT_URI || '';
-const OUTLOOK_ENABLED = process.env.OUTLOOK_ENABLED === 'true';
-const TOKEN_KEY = process.env.OUTLOOK_TOKEN_ENCRYPTION_KEY || '';
+import { env } from '../../_utils/env.js';
+const OUTLOOK_CLIENT_ID = env.outlook.clientId || '';
+const OUTLOOK_CLIENT_SECRET = env.outlook.clientSecret || '';
+const OUTLOOK_REDIRECT_URI = env.outlook.redirectUri || '';
+const OUTLOOK_ENABLED = env.outlook.enabled;
+const TOKEN_KEY = env.outlook.tokenEncryptionKey || '';
 
 const MICROSOFT_AUTH_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0';
 const SCOPES = 'openid profile email Calendars.ReadWrite offline_access';

--- a/api/_handlers/public/sms-notify.js
+++ b/api/_handlers/public/sms-notify.js
@@ -115,13 +115,13 @@ export default async function handler(req, res) {
 
             if (!twilioRes.ok) {
                 const errBody = await twilioRes.text().catch(() => '');
-                console.error(`[SMS] Twilio error (${twilioRes.status}): ${errBody}`);
+                logger.error(`[SMS] Twilio error (${twilioRes.status}): ${errBody}`);
             } else {
                 const smsResult = await twilioRes.json();
-                console.info(`[SMS] Sent to=${maskPhone(phoneNumber)} sid=${smsResult.sid}`);
+                logger.info(`[SMS] Sent to=${maskPhone(phoneNumber)} sid=${smsResult.sid}`);
             }
         } else {
-            console.warn(`[SMS] Twilio not configured — message queued locally: ${maskPhone(phoneNumber)}`);
+            logger.warn(`[SMS] Twilio not configured — message queued locally: ${maskPhone(phoneNumber)}`);
         }
 
         // Audit

--- a/api/_utils/env.js
+++ b/api/_utils/env.js
@@ -331,6 +331,36 @@ export const env = {
     },
   },
 
+  outlook: {
+    get enabled() {
+      return getEnv('OUTLOOK_ENABLED') === 'true';
+    },
+    get clientId() {
+      return getEnv('OUTLOOK_CLIENT_ID');
+    },
+    get clientSecret() {
+      return getEnv('OUTLOOK_CLIENT_SECRET');
+    },
+    get redirectUri() {
+      return getEnv('OUTLOOK_REDIRECT_URI');
+    },
+    get tokenEncryptionKey() {
+      return getEnv('OUTLOOK_TOKEN_ENCRYPTION_KEY');
+    },
+  },
+
+  siao: {
+    get enabled() {
+      return getEnv('SIAO_ENABLED') === 'true';
+    },
+    get apiUrl() {
+      return getEnv('SIAO_API_URL');
+    },
+    get apiKey() {
+      return getEnv('SIAO_API_KEY');
+    },
+  },
+
   flags: {
     get devLoginEnabled() {
       return getEnv('VITE_DEV_LOGIN_ENABLED') === 'true';

--- a/api/lib/crypto.js
+++ b/api/lib/crypto.js
@@ -1,7 +1,7 @@
 
-
 import crypto from 'crypto';
 import { env } from '../_utils/env.js';
+import logger from '../_utils/logger.js';
 
 // Encryption Algorithm
 // Encryption Algorithm
@@ -87,7 +87,7 @@ export function decrypt(encryptedText) {
 
         return decrypted;
     } catch (e) {
-        console.error("Decryption failed", e.message);
+        logger.error("Decryption failed", e.message);
         return null; // Tampered or wrong key
     }
 }
@@ -138,7 +138,7 @@ export function decryptBuffer(encryptedBuffer) {
 
         return Buffer.concat([decipher.update(text), decipher.final()]);
     } catch (e) {
-        console.error("Buffer Decryption failed", e.message);
+        logger.error("Buffer Decryption failed", e.message);
         return null;
     }
 }

--- a/api/lib/gemini.js
+++ b/api/lib/gemini.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { env } from '../_utils/env.js';
+import logger from '../_utils/logger.js';
 import prisma from '../_utils/prisma.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -45,7 +46,7 @@ function loadRulePack(id) {
         const path = join(__dirname, '../../src/data/rulepacks', `${id}.json`);
         return JSON.parse(readFileSync(path, 'utf8'));
     } catch (e) {
-        console.error(`Failed to load RulePack ${id}:`, e);
+        logger.error(`Failed to load RulePack ${id}:`, e);
         return null;
     }
 }
@@ -79,7 +80,7 @@ async function fetchRagContext(message, limit = 5) {
         return results || [];
     } catch (err) {
         // Graceful fallback: pgvector not enabled, no embeddings, or Gemini quota exceeded
-        console.warn('[RAG] Vector search unavailable, will try lexical fallback:', err.message);
+        logger.warn('[RAG] Vector search unavailable, will try lexical fallback:', err.message);
         return [];
     }
 }
@@ -142,10 +143,10 @@ async function fetchLexicalContext(message, limit = 5) {
             take: limit,
         });
 
-        console.info(`[Lexical] Found ${results.length} aides for keywords: ${keywords.join(', ')}`);
+        logger.info(`[Lexical] Found ${results.length} aides for keywords: ${keywords.join(', ')}`);
         return results;
     } catch (err) {
-        console.error('[Lexical] Fallback search failed:', err.message);
+        logger.error('[Lexical] Fallback search failed:', err.message);
         return [];
     }
 }
@@ -247,7 +248,7 @@ export async function chatWithRulePack(message, history = []) {
         return { answer: response.text(), meta };
     } catch (geminiError) {
         // ── 3. Static fallback when Gemini is down (429, network, etc.) ──
-        console.warn('[Gemini] Chat generation failed, using static fallback:', geminiError.message);
+        logger.warn('[Gemini] Chat generation failed, using static fallback:', geminiError.message);
 
         meta.searchMode = 'static';
 

--- a/api/lib/pro-auth.js
+++ b/api/lib/pro-auth.js
@@ -1,5 +1,6 @@
 
 import jwt from 'jsonwebtoken';
+import logger from '../_utils/logger.js';
 import prisma from '../_utils/prisma.js';
 import crypto from 'crypto';
 import { checkRateLimit as checkRateLimitUtil } from '../_utils/rateLimit.js';
@@ -166,7 +167,7 @@ export async function logProAudit(action, actorId, structureId, details, ip) {
             }
         });
     } catch (e) {
-        console.error("Audit Log Error", e);
+        logger.error("Audit Log Error", e);
     }
 }
 

--- a/api/lib/slug.js
+++ b/api/lib/slug.js
@@ -4,6 +4,7 @@
  */
 
 import slugify from '@sindresorhus/slugify';
+import logger from '../_utils/logger.js';
 
 /**
  * Generate a unique slug for a given text and Prisma model
@@ -83,14 +84,14 @@ export async function ensureSlug(prisma, modelName, item, titleField = 'titre') 
     const baseText = item[titleField];
 
     if (!baseText || typeof baseText !== 'string' || baseText.trim() === '') {
-        console.warn(`[Slug] Cannot generate slug for ${modelName} - missing ${titleField}`);
+        logger.warn(`[Slug] Cannot generate slug for ${modelName} - missing ${titleField}`);
         return null;
     }
 
     try {
         return await generateUniqueSlug(prisma, modelName, baseText, item.id || null);
     } catch (error) {
-        console.error(`[Slug] Error generating slug for ${modelName}:`, error.message);
+        logger.error(`[Slug] Error generating slug for ${modelName}:`, error.message);
         return null;
     }
 }

--- a/tests/integration/p14-sms-export-env.test.js
+++ b/tests/integration/p14-sms-export-env.test.js
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import apiHandler from '../../api/index.js';
+
+/**
+ * @param {Record<string, unknown>} overrides
+ */
+function createReq(overrides = {}) {
+    return {
+        method: overrides.method || 'POST',
+        url: overrides.url || '/api/public/sms-notify',
+        headers: {
+            host: 'localhost:3000',
+            'x-forwarded-for': '127.0.0.1',
+            'x-forwarded-proto': 'http',
+            ...(overrides.headers || {}),
+        },
+        query: overrides.query || {},
+        body: overrides.body || null,
+        cookies: {},
+    };
+}
+
+function createRes() {
+    const headers = {};
+    const finishListeners = [];
+    return {
+        statusCode: 200,
+        body: null,
+        headersSent: false,
+        on(event, listener) { if (event === 'finish') finishListeners.push(listener); return this; },
+        setHeader(key, value) { headers[key.toLowerCase()] = String(value); },
+        getHeader(key) { return headers[key.toLowerCase()]; },
+        status(code) { this.statusCode = code; return this; },
+        writeHead(code, h = {}) {
+            this.statusCode = code;
+            for (const [k, v] of Object.entries(h)) headers[k.toLowerCase()] = String(v);
+            return this;
+        },
+        json(p) { this.body = p; this.headersSent = true; for (const fn of finishListeners) fn(); return this; },
+        send(p) { this.body = p; this.headersSent = true; for (const fn of finishListeners) fn(); return this; },
+        end(p) { if (p !== undefined) this.body = p; this.headersSent = true; for (const fn of finishListeners) fn(); return this; },
+    };
+}
+
+async function invokeApi(url, options = {}) {
+    const req = createReq({ method: options.method, url, headers: options.headers, body: options.body });
+    const res = createRes();
+    await apiHandler(req, res);
+    return res;
+}
+
+/**
+ * P14 — SMS Notification & Dossier Export tests
+ *
+ * Verifies:
+ * 1. SMS handler validation (no Twilio creds → graceful fallback)
+ * 2. Dossier export handler requires auth + shareId
+ * 3. Env centralization for Outlook & SIAO
+ */
+describe('P14 — SMS Notification handler', () => {
+
+    it('GET /api/public/sms-notify → 405', async () => {
+        const res = await invokeApi('/api/public/sms-notify', { method: 'GET' });
+        expect(res.statusCode).toBe(405);
+    });
+
+    it('POST /api/public/sms-notify without body → 400', async () => {
+        const res = await invokeApi('/api/public/sms-notify', { method: 'POST', body: {} });
+        expect(res.statusCode).toBe(400);
+        expect(res.body?.error).toBeTruthy();
+    });
+
+    it('POST /api/public/sms-notify with invalid phone → 400', async () => {
+        const res = await invokeApi('/api/public/sms-notify', {
+            method: 'POST',
+            body: {
+                appointmentId: 'fake-id',
+                phoneNumber: '12345',
+            },
+        });
+        expect(res.statusCode).toBe(400);
+        expect(res.body?.error).toMatch(/numéro|téléphone|phone/i);
+    });
+
+    it('POST /api/public/sms-notify with valid phone but no DB appointment → 404 or 500', async () => {
+        const res = await invokeApi('/api/public/sms-notify', {
+            method: 'POST',
+            body: {
+                appointmentId: 'nonexistent-appointment-id',
+                phoneNumber: '06 12 34 56 78',
+            },
+        });
+        // 404 if Prisma finds nothing, 500 if no DB — both acceptable
+        expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    });
+});
+
+describe('P14 — Dossier Export handler', () => {
+
+    it('GET /api/pro/dossier/export without auth → 401', async () => {
+        const res = await invokeApi('/api/pro/dossier/export', { method: 'GET' });
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('POST /api/pro/dossier/export → 405', async () => {
+        const res = await invokeApi('/api/pro/dossier/export', { method: 'POST' });
+        // Method not allowed (handler only accepts GET) or 401 (auth check first)
+        expect([401, 405]).toContain(res.statusCode);
+    });
+});
+
+describe('P14 — Centralized env.outlook config', () => {
+
+    it('env.outlook getters exist and default to undefined/false', async () => {
+        const { env } = await import('../../api/_utils/env.js');
+        expect(env.outlook).toBeDefined();
+        expect(typeof env.outlook.enabled).toBe('boolean');
+        expect(env.outlook.clientId).toBeUndefined();
+        expect(env.outlook.clientSecret).toBeUndefined();
+        expect(env.outlook.redirectUri).toBeUndefined();
+        expect(env.outlook.tokenEncryptionKey).toBeUndefined();
+    });
+
+    it('env.siao getters exist and default to undefined/false', async () => {
+        const { env } = await import('../../api/_utils/env.js');
+        expect(env.siao).toBeDefined();
+        expect(typeof env.siao.enabled).toBe('boolean');
+        expect(env.siao.enabled).toBe(false);
+        expect(env.siao.apiUrl).toBeUndefined();
+        expect(env.siao.apiKey).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Objectif

Atteindre 100% de maturité Phase 2 en corrigeant tous les gaps P1→P3 identifiés par l'audit.

## Changements

### P1 — Console → Logger (15 appels corrigés)
- `api/lib/pro-auth.js`: `console.error` → `logger.error` + ajout import logger
- `api/_handlers/pro/outlook-availability.js`: 2× `console.info` → `logger.info`
- `api/_handlers/public/sms-notify.js`: 3× `console.*` → `logger.*`
- `api/lib/gemini.js`: 5× `console.*` → `logger.*` + ajout import logger
- `api/lib/slug.js`: 2× `console.*` → `logger.*` + ajout import logger
- `api/lib/crypto.js`: 2× `console.error` → `logger.error` + ajout import logger

### P2 — Centralisation Env Outlook + SIAO
- **`api/_utils/env.js`**: +`env.outlook.*` (5 vars) +`env.siao.*` (3 vars)
- `outlook.js`: `process.env.OUTLOOK_*` → `env.outlook.*`
- `outlook-availability.js`: `process.env.OUTLOOK_*` → `env.outlook.*`
- `outlook-callback.js`: `process.env.OUTLOOK_*` → `env.outlook.*`
- `interop-siao.js`: `process.env.SIAO_*` → `env.siao.*`
- `health-check.js`: `process.env.*` → `env.siao.*`/`env.ai.*`/`env.runtime.*`

### P3 — Tests Nouveaux
- `p14-sms-export-env.test.js`: **7 tests** — SMS validation, dossier export auth, env.outlook/env.siao config

## Validation

```
✅ npm run build         → Exit code 0
✅ npm run lint           → 0 erreurs
✅ npm run typecheck      → 0 erreurs
✅ npx vitest run         → 94 files, 475 tests, ALL PASS
```

## Fichiers modifiés (12)

| Fichier | Changement |
|---|---|
| `api/_utils/env.js` | +env.outlook.*, +env.siao.* |
| `api/lib/pro-auth.js` | console→logger |
| `api/lib/gemini.js` | console→logger |
| `api/lib/slug.js` | console→logger |
| `api/lib/crypto.js` | console→logger |
| `api/_handlers/pro/outlook.js` | env centralization |
| `api/_handlers/pro/outlook-availability.js` | env + console→logger |
| `api/_handlers/pro/interop-siao.js` | env centralization |
| `api/_handlers/pro/health-check.js` | env centralization |
| `api/_handlers/auth/outlook-callback.js` | env centralization |
| `api/_handlers/public/sms-notify.js` | console→logger |
| `tests/integration/p14-sms-export-env.test.js` | [NEW] 7 tests |

## Risques
- Zéro migration Prisma
- Seuls les appels `console.*` sont remplacés par `logger.*` (identique API)
- Les getters `env.*` retournent la même valeur que `process.env.*`