### PR TITLE
💎 P3 — Skeleton Screen Migration: Zero Loader Pro Pages

### DIFF
--- a/src/components/pro/ProPageSkeletons.jsx
+++ b/src/components/pro/ProPageSkeletons.jsx
@@ -1,0 +1,123 @@
+import { Skeleton } from '../ui/skeleton.jsx';
+
+/**
+ * ProPageSkeletons — Volumetric loading placeholders for Pro pages
+ *
+ * Replaces Loader2 spinners with layout-matching Skeleton screens
+ * to eliminate Cumulative Layout Shift (CLS) during page loads.
+ *
+ * Requirement 7.1 — Excellence Perceptuelle (NF-ADA)
+ */
+
+/**
+ * ListSkeleton — For pages displaying a list of items
+ * Used by: Appointments, Messages, RdvAbsences, Services (list section)
+ */
+export function ListSkeleton({ count = 4, title = true }) {
+    return (
+        <div className="space-y-4 animate-pulse">
+            {title && <Skeleton className="h-4 w-40 rounded-full mb-2" />}
+            {Array.from({ length: count }, (_, i) => (
+                <div key={i} className="flex items-center justify-between p-4 bg-white rounded-2xl border border-slate-100">
+                    <div className="flex items-center gap-3">
+                        <Skeleton className="h-10 w-10 rounded-xl" />
+                        <div className="space-y-2">
+                            <Skeleton className="h-3.5 w-36 rounded-full" />
+                            <Skeleton className="h-3 w-24 rounded-full" />
+                        </div>
+                    </div>
+                    <Skeleton className="h-8 w-20 rounded-lg" />
+                </div>
+            ))}
+        </div>
+    );
+}
+
+/**
+ * MessageThreadSkeleton — For chat/thread views
+ * Used by: MessageThread
+ */
+export function MessageThreadSkeleton() {
+    return (
+        <div className="space-y-4 animate-pulse">
+            {/* Header */}
+            <div className="flex items-center gap-3 p-4 border-b border-slate-100">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <div className="space-y-2">
+                    <Skeleton className="h-3.5 w-32 rounded-full" />
+                    <Skeleton className="h-3 w-20 rounded-full" />
+                </div>
+            </div>
+            {/* Messages */}
+            <div className="space-y-3 px-4">
+                <div className="flex justify-end">
+                    <Skeleton className="h-12 w-48 rounded-2xl rounded-tr-sm" />
+                </div>
+                <div className="flex justify-start">
+                    <Skeleton className="h-16 w-56 rounded-2xl rounded-tl-sm" />
+                </div>
+                <div className="flex justify-end">
+                    <Skeleton className="h-10 w-40 rounded-2xl rounded-tr-sm" />
+                </div>
+                <div className="flex justify-start">
+                    <Skeleton className="h-12 w-52 rounded-2xl rounded-tl-sm" />
+                </div>
+            </div>
+            {/* Input bar */}
+            <div className="flex items-center gap-2 p-4 border-t border-slate-100">
+                <Skeleton className="h-10 flex-1 rounded-xl" />
+                <Skeleton className="h-10 w-10 rounded-xl" />
+            </div>
+        </div>
+    );
+}
+
+/**
+ * FormSkeleton — For settings/form pages
+ * Used by: Structure, RdvNew, Services (settings section)
+ */
+export function FormSkeleton({ fields = 4 }) {
+    return (
+        <div className="space-y-6 animate-pulse">
+            <Skeleton className="h-5 w-48 rounded-full" />
+            {Array.from({ length: fields }, (_, i) => (
+                <div key={i} className="space-y-2">
+                    <Skeleton className="h-3.5 w-24 rounded-full" />
+                    <Skeleton className="h-10 w-full rounded-xl" />
+                </div>
+            ))}
+            <div className="flex justify-end pt-4">
+                <Skeleton className="h-10 w-32 rounded-xl" />
+            </div>
+        </div>
+    );
+}
+
+/**
+ * GridSkeleton — For time-grid / availability views
+ * Used by: Availability
+ */
+export function GridSkeleton({ cols = 5, rows = 4 }) {
+    return (
+        <div className="space-y-4 animate-pulse">
+            <div className="flex items-center justify-between">
+                <Skeleton className="h-5 w-48 rounded-full" />
+                <Skeleton className="h-9 w-28 rounded-xl" />
+            </div>
+            {/* Column headers */}
+            <div className="grid gap-2" style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
+                {Array.from({ length: cols }, (_, i) => (
+                    <Skeleton key={`h-${i}`} className="h-8 rounded-lg" />
+                ))}
+            </div>
+            {/* Grid cells */}
+            {Array.from({ length: rows }, (_, r) => (
+                <div key={r} className="grid gap-2" style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
+                    {Array.from({ length: cols }, (_, c) => (
+                        <Skeleton key={`${r}-${c}`} className="h-10 rounded-lg" />
+                    ))}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/pages/pro/Appointments.jsx
+++ b/src/pages/pro/Appointments.jsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Calendar, CheckCircle, Loader2, RefreshCw, XCircle } from 'lucide-react';
+import { ListSkeleton } from '@/components/pro/ProPageSkeletons';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -178,9 +179,7 @@ export default function ProAppointments() {
       ) : null}
 
       {loading ? (
-        <div className="flex items-center gap-2 text-sm text-slate-600">
-          <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
-        </div>
+        <ListSkeleton count={4} />
       ) : appointments.length === 0 ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-2 py-8 text-sm text-slate-600">

--- a/src/pages/pro/Availability.jsx
+++ b/src/pages/pro/Availability.jsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { useEffect, useState } from 'react';
 import { Clock, Loader2, Plus, Save, Trash2 } from 'lucide-react';
+import { GridSkeleton } from '@/components/pro/ProPageSkeletons';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -94,11 +95,7 @@ export default function ProAvailability() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center gap-2 text-sm text-slate-600">
-        <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
-      </div>
-    );
+    return <GridSkeleton cols={4} rows={7} />;
   }
 
   return (

--- a/src/pages/pro/MessageThread.jsx
+++ b/src/pages/pro/MessageThread.jsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
+import { MessageThreadSkeleton } from '@/components/pro/ProPageSkeletons';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -62,9 +62,7 @@ export default function ProMessageThread() {
 
         <CardContent className="space-y-4">
           {conversationQuery.isLoading ? (
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
-            </div>
+            <MessageThreadSkeleton />
           ) : null}
 
           {conversationQuery.error ? (

--- a/src/pages/pro/Messages.jsx
+++ b/src/pages/pro/Messages.jsx
@@ -1,7 +1,8 @@
 // @ts-nocheck
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, MessageCircle } from 'lucide-react';
+import { MessageCircle } from 'lucide-react';
+import { ListSkeleton } from '@/components/pro/ProPageSkeletons';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { rdvMessagingClient, messagingErrorText } from '@/api/rdv-messaging-client';
@@ -39,9 +40,7 @@ export default function ProMessages() {
 
         <CardContent className="space-y-3">
           {conversationsQuery.isLoading ? (
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <Loader2 className="h-4 w-4 animate-spin" /> Chargement des conversations...
-            </div>
+            <ListSkeleton count={3} />
           ) : null}
 
           {conversationsQuery.error ? (

--- a/src/pages/pro/RdvAbsences.jsx
+++ b/src/pages/pro/RdvAbsences.jsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2, Pencil, Trash2 } from 'lucide-react';
+import { ListSkeleton } from '@/components/pro/ProPageSkeletons';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -175,9 +176,7 @@ export default function ProRdvAbsences() {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
-            </div>
+            <ListSkeleton count={3} />
           ) : items.length === 0 ? (
             <p className="text-sm text-slate-600">Aucune absence configuree.</p>
           ) : (

--- a/src/pages/pro/RdvNew.jsx
+++ b/src/pages/pro/RdvNew.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
+import { ListSkeleton } from '@/components/pro/ProPageSkeletons';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -225,9 +226,7 @@ export default function ProRdvNew() {
         </CardHeader>
         <CardContent className="space-y-3">
           {loadingSlots ? (
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
-            </div>
+            <ListSkeleton count={4} title={false} />
           ) : slots.length === 0 ? (
             <p className="text-sm text-slate-600">Aucun creneau charge.</p>
           ) : (
@@ -239,9 +238,8 @@ export default function ProRdvNew() {
                     key={slot.startAt}
                     type="button"
                     onClick={() => setSelectedSlot(slot)}
-                    className={`rounded-md border px-3 py-2 text-left text-sm ${
-                      active ? 'border-blue-300 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'
-                    }`}
+                    className={`rounded-md border px-3 py-2 text-left text-sm ${active ? 'border-blue-300 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'
+                      }`}
                   >
                     <div className="font-medium">{formatSlot(slot.startAt)}</div>
                     <div className="text-xs text-slate-500">Fin: {formatSlot(slot.endAt)}</div>

--- a/src/pages/pro/Services.jsx
+++ b/src/pages/pro/Services.jsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { AlertTriangle, Edit, ExternalLink, Loader2, Plus, Power, Save, Trash2 } from 'lucide-react';
+import { FormSkeleton, ListSkeleton } from '@/components/pro/ProPageSkeletons';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -255,9 +256,7 @@ export default function ProServices() {
           ) : null}
 
           {settingsLoading ? (
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <Loader2 className="h-4 w-4 animate-spin" /> Chargement des parametres RDV...
-            </div>
+            <FormSkeleton fields={3} />
           ) : (
             <form className="space-y-4" onSubmit={saveSettings}>
               <label className="flex items-center gap-2 text-sm text-slate-700">
@@ -360,9 +359,7 @@ export default function ProServices() {
       ) : null}
 
       {loading ? (
-        <div className="flex items-center gap-2 text-sm text-slate-600">
-          <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
-        </div>
+        <ListSkeleton count={3} />
       ) : services.length === 0 ? (
         <Card>
           <CardContent className="py-6 text-sm text-slate-600">Aucun service configure.</CardContent>
@@ -375,9 +372,8 @@ export default function ProServices() {
                 <CardTitle className="flex items-center justify-between gap-2">
                   <span>{service.name}</span>
                   <span
-                    className={`rounded-full px-2 py-1 text-xs ${
-                      service.isActive ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-700'
-                    }`}
+                    className={`rounded-full px-2 py-1 text-xs ${service.isActive ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-700'
+                      }`}
                   >
                     {service.isActive ? 'Actif' : 'Inactif'}
                   </span>

--- a/src/pages/pro/Structure.jsx
+++ b/src/pages/pro/Structure.jsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Loader2 } from 'lucide-react';
+import { FormSkeleton } from '@/components/pro/ProPageSkeletons';
 
 export default function ProStructure() {
     useOutletContext();
@@ -81,7 +82,7 @@ export default function ProStructure() {
         }
     };
 
-    if (loading) return <Loader2 className="animate-spin" />;
+    if (loading) return <FormSkeleton fields={3} />;
 
     return (
         <div className="space-y-6">


### PR DESCRIPTION
## 💎 P3 — Excellence Perceptuelle : Migration Skeleton Screens

### Objectif
Éradiquer 100% des indicateurs de chargement pleine page (`Loader2 + Chargement...`) dans l'Espace Pro pour éliminer le Cumulative Layout Shift (CLS) et stabiliser le flux visuel (Requirement 7.1 NF-ADA).

---

### 🧩 Composant Créé

**[`ProPageSkeletons.jsx`](src/components/pro/ProPageSkeletons.jsx)** — 4 variantes volumétriques réutilisables :

| Variante | Usage | Description |
|---|---|---|
| `ListSkeleton` | Appointments, Messages, RdvAbsences, Services | Items avec avatar + texte + action |
| `MessageThreadSkeleton` | MessageThread | Bulles de chat alternées + barre de saisie |
| `FormSkeleton` | Structure, Services settings, RdvNew | Champs label + input + bouton submit |
| `GridSkeleton` | Availability | Grille jours × créneaux horaires |

### 📝 Pages Migrées (9 points d'intervention)

| Page | Ligne | Avant | Après |
|---|---|---|---|
| `Structure.jsx` | :84 | `if(loading) return <Loader2>` | `<FormSkeleton fields={3}>` |
| `Messages.jsx` | :43 | `Chargement des conversations...` | `<ListSkeleton count={3}>` |
| `MessageThread.jsx` | :66 | `Chargement...` | `<MessageThreadSkeleton>` |
| `Appointments.jsx` | :182 | `Chargement...` | `<ListSkeleton count={4}>` |
| `RdvAbsences.jsx` | :179 | `Chargement...` | `<ListSkeleton count={3}>` |
| `RdvNew.jsx` | :229 | `Chargement...` | `<ListSkeleton count={4}>` |
| `Availability.jsx` | :99 | `Chargement...` | `<GridSkeleton cols={4} rows={7}>` |
| `Services.jsx` | :259 | `Chargement parametres RDV...` | `<FormSkeleton fields={3}>` |
| `Services.jsx` | :364 | `Chargement...` | `<ListSkeleton count={3}>` |

> 🔧 **Spinners de boutons** (save, confirm, cancel) **conservés** — c'est une bonne pratique UX qui ne cause pas de CLS.

### ✅ Vérification Triple

| Check | Résultat |
|---|---|
| `grep -r "Loader2.*Chargement" src/pages/pro/` | **0 matches** ✅ |
| `npm run build` | **exit 0** ✅ |
| `npx vitest run` | **310/310 tests** ✅ |

### 📊 Impact

- **9 pages migrées** — zéro saut de texte pendant le chargement
- **1 composant** — 4 variantes réutilisables pour toute future page Pro
- **145 lignes ajoutées / 35 supprimées** — diff net et chirurgical