### PR TITLE
🌙 PR #3 : Finalisation Dark Mode — Palette Zinc/Slate + ADA Teal

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -55,28 +55,25 @@
     --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-    --primary: 243 75% 59%;
-    /* Indigo-600: #4f46e5 */
+    --primary: 174 74% 26%;
+    /* ADA Teal */
     --primary-foreground: 210 40% 98%;
-    --secondary: 161 94% 30%;
-    /* Emerald-600 */
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 38%;
-    --accent: 38 92% 50%;
-    /* Amber-500: #f59e0b */
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 84% 60%;
-    /* Red-500 */
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
-    --radius: 0.5rem;
+    --radius: 0.75rem;
 
-    /* Chart Palette — Indigo/Emerald/Amber institutional triad */
-    --chart-1: 243 75% 59%;
-    /* Indigo-600 */
+    /* Chart Palette — Institutional triad */
+    --chart-1: 174 74% 26%;
+    /* ADA Teal */
     --chart-2: 161 94% 30%;
     /* Emerald-600 */
     --chart-3: 38 92% 50%;
@@ -104,13 +101,13 @@
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 243 75% 59%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 161 94% 30%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
-    --accent: 38 92% 50%;
+    --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;


### PR DESCRIPTION
## 📝 Description

Cette PR complète l'implémentation du mode sombre en injectant les variables HSL Shadcn/UI dans le fichier CSS global. Le toggle et la configuration Tailwind (`darkMode: ["class"]`) étaient déjà en place, mais les tokens de design de la palette `.dark` n'étaient pas alignés sur le standard Zinc/Slate.

**Impact** : Expérience utilisateur premium et conforme aux standards d'accessibilité (contraste élevé en mode nuit).

## 🛠️ Modifications

### `src/index.css` — Tokens de design

#### Light Mode (`:root`)
| Token | Avant | Après | Raison |
|---|---|---|---|
| `--primary` | `243 75% 59%` (Indigo) | `174 74% 26%` (ADA Teal) | Identité visuelle AccesDirectAide |
| `--secondary` | `161 94% 30%` (Emerald) | `210 40% 96.1%` | Standard Shadcn neutral |
| `--accent` | `38 92% 50%` (Amber) | `210 40% 96.1%` | Standard Shadcn neutral |
| `--radius` | `0.5rem` | `0.75rem` | Look plus arrondi et premium |

#### Dark Mode (`.dark`)
| Token | Avant | Après | Raison |
|---|---|---|---|
| `--primary` | `243 75% 59%` (Indigo) | `210 40% 98%` | Inversé : texte clair sur fond sombre |
| `--primary-foreground` | `210 40% 98%` | `222.2 47.4% 11.2%` | Inversé |
| `--secondary` | `161 94% 30%` | `217.2 32.6% 17.5%` | Zinc 800 |
| `--accent` | `38 92% 50%` | `217.2 32.6% 17.5%` | Zinc 800 |

### Infrastructure déjà en place
- ✅ `DarkModeToggle` dans `Layout.jsx` (toggle `.dark` sur `<html>`)
- ✅ `tailwind.config.js` : `darkMode: ["class"]`
- ✅ `@layer base { body { @apply bg-background text-foreground } }`

## 🎨 Palette Sombre (Design Tokens)
- **Background** : Bleu-nuit profond (`222.2 84% 4.9%`)
- **Foreground** : Blanc cassé (`210 40% 98%`)
- **Muted** : Gris-bleu ardoise (`217.2 32.6% 17.5%`)
- **Primary** : Blanc (inversé pour contraste sur fond sombre)

## ✅ Vérification

- [x] `npm run build` ✅
- [x] Test visuel : basculement dark/light fonctionne, contrastes validés
- [x] Hero, footer, assistant s'adaptent parfaitement
- [ ] Note : certaines cartes hompage utilisent `bg-white` hardcodé (amélioration future avec `dark:bg-card`)