### PR TITLE
🔧 fix: target api/index.js for maxDuration (single entry point)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "api/cron/*.js": {
+    "api/index.js": {
       "maxDuration": 300
     }
   },


### PR DESCRIPTION
All API routes rewrite to api/index.js via vercel.json rewrites. The previous api/cron/*.js pattern never matched any serverless function, which is why maxDuration: 300 had no effect.

## Objectif
<!-- Pourquoi ce changement ? Quel ticket/issue cela résout-il ? -->

## Scope (fichiers)
<!-- Liste technique des modifications. Ex: -->
<!-- - Ajout de X -->
<!-- - Modification de Y -->

## Checklist DoD (Definition of Done)
- [ ] Le préflight local passe (`npm run preflight`)
- [ ] Pas de couleurs hardcodées (#xxxxxx) dans `src/components/**`
- [ ] Pas de classes palette type `bg-blue-500` / `text-slate-400` dans `src/components/ui/**`
- [ ] Stories Storybook obligatoires pour composants DS (si applicable)
- [ ] Pas de secrets ou données sensibles commités
- [ ] Documentation mise à jour (si nécessaire)

## Démo
<!-- Ce que le reviewer doit vérifier (Screenshots, GIFs, ou commandes à lancer) -->

## Risques / Rollback
<!-- Quels sont les risques potentiels ? Comment revenir en arrière rapidement ? -->
